### PR TITLE
use 'cargo install' with '--locked' flag for amareleo-chain

### DIFF
--- a/amareleo.Dockerfile
+++ b/amareleo.Dockerfile
@@ -33,7 +33,7 @@ ARG RUST_VERSION
 RUN rustup toolchain install ${RUST_VERSION} --force && rustup default ${RUST_VERSION}
 
 # Compile with optimizations
-RUN cargo +${RUST_VERSION} install --path .
+RUN cargo +${RUST_VERSION} install --locked --path .
 
 # Stage 2: Create final minimal image
 FROM debian:${DEBIAN_RELEASE}-slim


### PR DESCRIPTION
Ensuring reproducible builds for 'amareleo-chain'. Dependency resolution in consistent with the lockfile with no implicit updates during build

see: https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile
