### PR TITLE
update rust toolchain v1.85.1 -> v1.88.0 as required by leo v3+

### DIFF
--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -2,7 +2,7 @@
 
 ARG NODE_VERSION=22
 ARG DEBIAN_RELEASE=bookworm
-ARG RUST_VERSION=1.85.1
+ARG RUST_VERSION=1.88.0
 
 # Stage 1: Build leo-lang from source
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as builder


### PR DESCRIPTION
'leo-lang' and 'leo-lang-ci' images for leo CLI v3.1.0 have been built and published:
- https://github.com/sealance-io/compliant-transfer-aleo/pkgs/container/leo-lang/491000246?tag=v3.1.0
- https://github.com/sealance-io/aleo-containers/pkgs/container/leo-lang-ci/491022203?tag=v3.1.0