### PR TITLE
build leo devnet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,126 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+This repository provides Docker containerization for the Aleo blockchain ecosystem, including Leo Lang (aleo CLI), Amareleo Chain (devnet blockchain single node), and integrated devnet environments.
+
+## Essential Commands
+
+### Building Docker Images
+
+```bash
+# Leo Lang standard image (with Node.js)
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --no-push
+
+# Leo Lang CI image (with full Rust toolchain)
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --ci --no-push
+
+# Both Leo Lang variants
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --both --no-push
+
+# Amareleo Chain image
+./build-publish-image.sh --dockerfile amareleo.Dockerfile --image-name amareleo-chain --no-push
+
+# Aleo Devnet integrated image (Leo + snarkOS)
+./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --no-push
+
+# Local development builds (single architecture, faster)
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --local-arch --no-push
+```
+
+### Running Containers
+
+```bash
+# Run Leo Lang CLI
+docker run --rm ghcr.io/sealance-io/leo-lang:v2.7.1 leo --help
+
+# Run Aleo devnet (Leo v3 + snarkOS)
+docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/data aleo-devnet
+
+# Run local testnet with docker-compose (4 validators + 1 client)
+docker-compose up -d
+
+# Access REST API after testnet starts
+curl http://localhost:3030/testnet3/latest/height
+```
+
+### Publishing Images (requires GitHub registry login)
+
+```bash
+# Login to GitHub Container Registry
+echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
+
+# Build and push with version tagging
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
+
+# Build without 'latest' tag
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --no-latest
+```
+
+## Architecture & Key Relationships
+
+### Dockerfile Structure
+
+All Dockerfiles use multi-stage builds:
+
+1. **leo.Dockerfile**: 
+   - Stage 1 (`builder`): Compiles Leo from source using Rust
+   - Stage 2 (`leo`): Minimal runtime with Node.js
+   - Stage 3 (`leo-ci`): Full CI environment with Rust, Docker, Git
+
+2. **amareleo.Dockerfile**:
+   - Stage 1 (`builder`): Compiles Amareleo Chain from source
+   - Stage 2 (final): Minimal runtime for blockchain node
+
+3. **aleo-devnet.Dockerfile**:
+   - Stage 1 (`leo-builder`): Builds Leo v3 with devnet patch
+   - Stage 2 (`snarkos-builder`): Builds snarkOS v4.1.0
+   - Stage 3 (final): Combined runtime with pre-downloaded provers
+
+### Critical Implementation Details
+
+**Leo Devnet Patch**: The aleo-devnet.Dockerfile patches Leo's source at leo/cli/commands/devnet/mod.rs:35-40 to respect the `--yes` flag for non-interactive devnet startup. This is essential for containerized operation.
+
+**Prover Downloads**: The `download-provers.sh` script downloads mainnet/testnet parameter files to `/.aleo/resources/`. These are required for zero-knowledge proof generation and are pre-cached in images to avoid runtime downloads.
+
+**Version Dependencies**:
+- Leo v3+ requires Rust 1.88.0 (updated from 1.85.1)
+- Leo v2.7.1 and earlier use Rust 1.85.1
+- snarkOS v4.1.0 requires specific build features: `default,snarkos-node-metrics,test_network`
+
+**Docker Compose Network**: Uses fixed IP addressing (172.20.0.0/16) with:
+- validator0: 172.20.0.2 (verbose logging, REST disabled)
+- validator1-3: 172.20.0.3-5 (quiet logging)
+- client0: 172.20.0.6 (REST API on port 3030)
+
+### Build Script Intelligence
+
+The `build-publish-image.sh` script:
+- Auto-detects Docker vs Podman
+- Sets up multi-arch builders dynamically
+- Handles version-specific build arguments based on image name
+- Retries failed pushes up to 3 times with 10-second delays
+- Uses script directory as build context (important for COPY commands)
+
+### Environment Variables for Customization
+
+```bash
+# Override versions
+LEO_VERSION="v2.7.1" ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
+AMARELEO_VERSION="v2.5.0" ./build-publish-image.sh --dockerfile amareleo.Dockerfile --image-name amareleo-chain
+LEO_VERSION="v3.1.0" SNARKOS_VERSION="v4.1.0" ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
+
+# Override repositories (for forks)
+LEO_REPO="https://github.com/your-fork/leo" ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
+AMARELEO_REPO="https://github.com/your-fork/amareleo-chain" ./build-publish-image.sh --dockerfile amareleo.Dockerfile --image-name amareleo-chain
+
+# Other overrides
+NODE_VERSION=18 DEBIAN_RELEASE=bullseye ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
+RUST_VERSION=1.88.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
+```
+
+## Current Working Branch
+
+The current branch is `or/build_leo_devnet` which adds the new aleo-devnet.Dockerfile for integrated Leo + snarkOS development environment. Main branch is `main`.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This repository provides Docker images for Aleo blockchain tooling:
 
 - **Leo Lang Images**: The Leo programming language CLI tool designed for building and running zero-knowledge applications
 - **Amareleo Chain Images**: The Amareleo blockchain node implementation
+- **Aleo Devnet Image**: Integrated development environment with Leo v3 and snarkOS for running local test networks
 
-Each image is available in two variants:
+Image variants available:
 
 - **Standard Image**: Contains the core CLI tools with necessary runtime dependencies
-- **CI Image**: Extended version with additional tools for CI/CD pipelines and GitHub Actions workflows
+- **CI Image**: Extended version with additional tools for CI/CD pipelines and GitHub Actions workflows (Leo Lang only)
+- **Devnet Image**: Combined Leo and snarkOS for local blockchain development
 
 All images are multi-architecture, supporting AMD64 and ARM64 platforms.
 
@@ -24,6 +26,9 @@ Pre-built images are available on GitHub Container Registry:
 
 #### Amareleo Chain
 - **Standard**: `ghcr.io/sealance-io/amareleo-chain:v2.5.0`
+
+#### Aleo Devnet
+- **Integrated**: `ghcr.io/sealance-io/aleo-devnet:v3.1.0-v4.1.0`
 
 You can also use the `latest` tag to always get the most recent version.
 
@@ -51,6 +56,14 @@ You can also use the `latest` tag to always get the most recent version.
 - Debian Bookworm (slim)
 - Essential SSL libraries
 - Running as non-root user
+
+#### Aleo Devnet Image (`aleo-devnet`)
+- Leo CLI v3.1.0 (with devnet patch for non-interactive mode)
+- snarkOS v4.1.0
+- Pre-downloaded mainnet prover parameters (~2GB)
+- Debian Bookworm (slim)
+- Essential runtime libraries
+- Configured for local development
 
 ## 🚀 Usage
 
@@ -106,13 +119,43 @@ For running an Amareleo blockchain node:
 # Run node with default settings
 docker run -d -p 3030:3030 -p 9000:9000 \
   -v $(pwd)/data:/data/amareleo \
-  ghcr.io/sealance-io/amareleo-chain:v2.3.0
+  ghcr.io/sealance-io/amareleo-chain:v2.5.0
 
 # Run with custom parameters
 docker run -d -p 3030:3030 -p 9000:9000 \
   -v $(pwd)/data:/data/amareleo \
-  ghcr.io/sealance-io/amareleo-chain:v2.3.0 \
-  amareleo-chain start --network 2 --verbosity 2 --rest 0.0.0.0:3030
+  ghcr.io/sealance-io/amareleo-chain:v2.5.0 \
+  start --network 2 --verbosity 2 --rest 0.0.0.0:3030
+```
+
+### Aleo Devnet Image
+
+For running a local Aleo development network with Leo v3 and snarkOS:
+
+```bash
+# Run a minimal devnet (4 validators + 1 client)
+docker run -it --rm -p 3030:3030 -p 4130:4130 \
+  -v $(pwd)/data:/data \
+  ghcr.io/sealance-io/aleo-devnet:v3.1.0-v4.1.0
+
+# Run with custom devnet parameters
+docker run -it --rm -p 3030:3030 -p 4130:4130 \
+  -v $(pwd)/data:/data \
+  ghcr.io/sealance-io/aleo-devnet:v3.1.0-v4.1.0 \
+  devnet --storage /data --clear-storage --yes \
+  --verbosity 4 --num-validators 4 --num-clients 2
+
+# Run snarkOS directly instead of Leo devnet command
+docker run -it --rm -p 3030:3030 -p 4130:4130 \
+  --entrypoint ./snarkos \
+  ghcr.io/sealance-io/aleo-devnet:v3.1.0-v4.1.0 \
+  start --client --nodisplay --node 0.0.0.0:4130 \
+  --network 1 --dev 0 --rest 0.0.0.0:3030
+
+# Access Leo CLI for development
+docker run -it --rm -v $(pwd):/app -w /app \
+  ghcr.io/sealance-io/aleo-devnet:v3.1.0-v4.1.0 \
+  new my_project
 ```
 #### GitHub Actions Example
 
@@ -150,6 +193,9 @@ The project consists of the following files:
 ├── build-publish-image.sh    # Build script for creating and publishing images
 ├── leo.Dockerfile            # Multi-stage Dockerfile for Leo Lang
 ├── amareleo.Dockerfile       # Multi-stage Dockerfile for Amareleo Chain
+├── aleo-devnet.Dockerfile    # Multi-stage Dockerfile for Aleo Devnet (Leo + snarkOS)
+├── docker-compose.yaml       # Docker Compose setup for local testnet
+├── download-provers.sh       # Script to download Aleo prover parameters
 └── README.md                 # This documentation file
 ```
 
@@ -164,6 +210,33 @@ The build script automatically:
 This repository includes automated workflows for building and publishing images.
 
 For detailed information about the CI/CD workflows, please see the [CI/CD documentation](./docs/CI.md).
+
+## 🌐 Docker Compose Local Testnet
+
+The `docker-compose.yaml` file sets up a local Aleo testnet with:
+- 4 validator nodes (validator0-3)
+- 1 client node with REST API
+- Fixed IP addressing for consistent peer connections
+- REST API exposed on port 3030
+
+To run the local testnet:
+
+```bash
+# Start the testnet
+docker-compose up -d
+
+# Check status
+docker-compose ps
+
+# View logs
+docker-compose logs -f validator0
+
+# Access REST API
+curl http://localhost:3030/testnet3/latest/height
+
+# Stop the testnet
+docker-compose down
+```
 
 ## 🔧 Building Images Locally
 
@@ -191,6 +264,9 @@ cat ~/.github/token | docker login ghcr.io --username USERNAME --password-stdin
 
 # Build standard Amareleo Chain image
 ./build-publish-image.sh --dockerfile amareleo.Dockerfile --image-name amareleo-chain
+
+# Build Aleo Devnet image (Leo v3 + snarkOS)
+./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Build without tagging as latest
 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --both --no-latest
@@ -232,6 +308,12 @@ AMARELEO_VERSION="v2.5.0" ./build-publish-image.sh --dockerfile amareleo.Dockerf
 
 # Override Amareleo repository URL
 AMARELEO_REPO="https://github.com/your-fork/amareleo-chain" ./build-publish-image.sh --dockerfile amareleo.Dockerfile --image-name amareleo-chain
+
+# Override Aleo Devnet versions (Leo and snarkOS)
+LEO_VERSION="v3.1.0" SNARKOS_VERSION="v4.1.0" ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
+
+# Override Rust version for Aleo Devnet
+RUST_VERSION="1.88.0" ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Override Node.js version (Leo Lang only)
 NODE_VERSION=18 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -1,0 +1,151 @@
+# aleo-devnet.Dockerfile - Leo CLI with snarkOS for local devnet testing
+# Build: docker build -f aleo-devnet.Dockerfile -t aleo-devnet .
+# Run: docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/data aleo-devnet
+
+# Build arguments
+ARG LEO_VERSION=v3.1.0
+ARG SNARKOS_VERSION=v4.1.0
+ARG RUST_VERSION=1.88.0
+
+# Stage 1: Build Leo CLI
+FROM rust:${RUST_VERSION}-bookworm AS leo-builder
+
+ARG LEO_VERSION
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libssl-dev \
+    pkg-config \
+    patch \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and build Leo
+WORKDIR /build
+RUN git clone --branch ${LEO_VERSION} --depth 1 \
+    https://github.com/ProvableHQ/leo.git
+
+WORKDIR /build/leo
+
+RUN sed -i \
+    's/if\s*!\s*confirm\s*(\s*"\\nProceed with devnet startup?"\s*,\s*false\s*)\s*?/if !confirm("\\nProceed with devnet startup?", self.yes)?/' \
+    leo/cli/commands/devnet/mod.rs && \
+    echo "Patched devnet/mod.rs to respect --yes flag" && \
+    # Verify the patch was applied by checking for the presence of self.yes
+    grep -q 'confirm.*self\.yes' leo/cli/commands/devnet/mod.rs && \
+    echo "Patch verified successfully" || (echo "Patch verification failed" && exit 1)
+
+# Build Leo in release mode with default features from repository
+RUN cargo build --release --locked && \
+    mv target/release/leo /tmp/leo && \
+    strip /tmp/leo
+
+# Stage 2: Build snarkOS
+FROM rust:${RUST_VERSION}-bookworm AS snarkos-builder
+
+ARG SNARKOS_VERSION
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    clang \
+    cmake \
+    curl \
+    gcc \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    llvm \
+    make \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and build snarkOS
+WORKDIR /build
+RUN git clone --branch ${SNARKOS_VERSION} --depth 1 \
+    https://github.com/ProvableHQ/snarkOS.git
+
+WORKDIR /build/snarkOS
+
+# Build snarkOS in release mode with specified features
+# Using the standard feature set for devnet operation
+RUN cargo build --release --locked \
+    --features "default,snarkos-node-metrics,test_network" && \
+    mv target/release/snarkos /tmp/snarkos && \
+    strip /tmp/snarkos
+
+# Stage 3: Final runtime image
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    libcurl4 \
+    curl \
+    wget \
+    procps \
+    net-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /aleo
+
+# Copy binaries from builders
+COPY --from=leo-builder /tmp/leo /usr/local/bin/leo
+COPY --from=snarkos-builder /tmp/snarkos /aleo/snarkos
+
+# Make binaries executable
+RUN chmod +x /usr/local/bin/leo /aleo/snarkos
+
+# Create data directory for blockchain storage
+RUN mkdir -p /data
+
+# Verify installations
+RUN leo --version && \
+    ./snarkos --version
+
+RUN mkdir -p /.aleo
+
+# Copy download-provers.sh and set ownership
+COPY download-provers.sh /tmp/
+
+# Run the download-provers script as leo user
+RUN /tmp/download-provers.sh
+
+# Set environment variables for better devnet operation
+ENV RUST_LOG=info \
+    RUST_BACKTRACE=1
+
+# Expose ports
+# 3030: REST API
+# 4130: Node communication
+# 4180: Metrics (if enabled)
+EXPOSE 3030 4130 4180
+
+# Volume for persistent storage
+VOLUME ["/data"]
+
+# Default entrypoint is leo
+ENTRYPOINT ["/usr/local/bin/leo"]
+
+# Default command runs a minimal devnet
+# --storage: Use /data for blockchain storage
+# --clear-storage: Clean start each time
+# --yes: Auto-confirm prompts (now respected due to patch)
+# --verbosity 4: Maximum debug output
+# --snarkos: Use our pre-built binary
+# --num-clients: Single client for minimal setup
+CMD ["devnet", "--storage", "/data", "--clear-storage", "--yes", "--verbosity", "4", "--snarkos", "./snarkos", "--num-clients", "1"]
+
+# Build metadata
+ARG LEO_VERSION
+ARG SNARKOS_VERSION
+LABEL org.opencontainers.image.title="Aleo Devnet" \
+      org.opencontainers.image.description="Leo CLI with snarkOS for local Aleo development network" \
+      org.opencontainers.image.documentation="https://developer.aleo.org" \
+      leo.version="${LEO_VERSION}" \
+      snarkos.version="${SNARKOS_VERSION}" \
+      build.features="default,snarkos-node-metrics,test_network"

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 RUN git clone --branch ${LEO_VERSION} --depth 1 \
     https://github.com/ProvableHQ/leo.git
+# Force rust to use external Git instead of the internal libgit wrapper
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 WORKDIR /build/leo
 
@@ -53,7 +55,9 @@ RUN apt-get update && apt-get install -y \
     clang \
     cmake \
     curl \
-    gcc \
+	clang \
+	gcc \
+    lld \
     libssl-dev \
     libcurl4-openssl-dev \
     llvm \
@@ -66,6 +70,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 RUN git clone --branch ${SNARKOS_VERSION} --depth 1 \
     https://github.com/ProvableHQ/snarkOS.git
+# Force rust to use external Git instead of the internal libgit wrapper
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 WORKDIR /build/snarkOS
 

--- a/build-publish-image.sh
+++ b/build-publish-image.sh
@@ -211,6 +211,22 @@ elif [[ "$IMAGE_NAME" == "amareleo-chain" ]]; then
   PROJECT_VERSION_ARG="AMARELEO_VERSION"
   PROJECT_REPO=${AMARELEO_REPO:-"https://github.com/kaxxa123/amareleo-chain"}
   PROJECT_REPO_ARG="AMARELEO_REPO"
+elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
+  # Aleo-devnet doesn't support CI image
+  if [[ "$BUILD_CI" == "true" ]]; then
+    echo "Error: CI image is not available for aleo-devnet"
+    echo "Use --standard instead of --ci or --both"
+    exit 1
+  fi
+  
+  # Aleo-devnet uses both LEO and SNARKOS versions
+  LEO_VERSION=${LEO_VERSION:-"v3.1.0"}
+  SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.1.0"}
+  PROJECT_VERSION="${LEO_VERSION}-${SNARKOS_VERSION}"
+  # For aleo-devnet, we'll pass both versions as build args
+  PROJECT_VERSION_ARG="LEO_VERSION"
+  PROJECT_REPO=""  # Not applicable for aleo-devnet
+  PROJECT_REPO_ARG=""
 else
   echo "Error: Unknown image name: $IMAGE_NAME"
   echo "Please specify a supported image name with --image-name"
@@ -219,7 +235,9 @@ fi
 
 echo "Building for $IMAGE_NAME with $DOCKERFILE"
 echo "Version: $PROJECT_VERSION"
-echo "Repository: $PROJECT_REPO"
+if [[ -n "$PROJECT_REPO" ]]; then
+  echo "Repository: $PROJECT_REPO"
+fi
 
 # Check registry credentials if we're pushing
 check_registry_credentials
@@ -243,11 +261,24 @@ build_and_push() {
   echo "Push to registry: $([ "$PUSH_IMAGES" == "true" ] && echo "Yes" || echo "No")"
 
   # Common build arguments for both podman and docker
-  local common_build_args=(
-    "--build-arg" "${PROJECT_VERSION_ARG}=${PROJECT_VERSION}"
-    "--build-arg" "${PROJECT_REPO_ARG}=${PROJECT_REPO}"
-    "--build-arg" "DEBIAN_RELEASE=${DEBIAN_RELEASE}"
-  )
+  local common_build_args=()
+  
+  # Handle build args based on image type
+  if [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
+    # Aleo-devnet needs both LEO_VERSION and SNARKOS_VERSION
+    common_build_args+=(
+      "--build-arg" "LEO_VERSION=${LEO_VERSION}"
+      "--build-arg" "SNARKOS_VERSION=${SNARKOS_VERSION}"
+      "--build-arg" "RUST_VERSION=${RUST_VERSION:-1.88.0}"
+    )
+  else
+    # Standard images use PROJECT_VERSION_ARG and PROJECT_REPO_ARG
+    common_build_args+=("--build-arg" "${PROJECT_VERSION_ARG}=${PROJECT_VERSION}")
+    if [[ -n "$PROJECT_REPO_ARG" ]]; then
+      common_build_args+=("--build-arg" "${PROJECT_REPO_ARG}=${PROJECT_REPO}")
+    fi
+    common_build_args+=("--build-arg" "DEBIAN_RELEASE=${DEBIAN_RELEASE}")
+  fi
   
   # Add NODE_VERSION arg only for leo-lang image
   if [[ "$IMAGE_NAME" == "leo-lang" ]]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,18 @@
 services:
   validator0:
-    image: aleohq/snarkos:latest
+    image: localhost/snarkos:devnet-v4.1.0
     container_name: validator0
-    entrypoint: ["/aleo/bin/snarkos"]
+    entrypoint: ["snarkos"]
     command: [
       "start", "--nodisplay", "--bft", "0.0.0.0:5000", "--node", "0.0.0.0:4130", "--network", "1", "--dev", "0",
-      "--dev-num-validators", "4", "--validator", "--allow-external-peers", 
+      "--dev-num-validators", "4", "--validator", "--no-dev-txs", "--allow-external-peers", 
       "--peers", "172.20.0.3:4130,172.20.0.4:4130,172.20.0.5:4130,172.20.0.6:4130",
       "--validators", "172.20.0.3:5000,172.20.0.4:5000,172.20.0.5:5000",
-      "--norest"
+      "--norest", "--verbosity", "5"
     ]
+    # environment: 
+    #   CONSENSUS_VERSION_HEIGHTS: 0,1,2,3,4,5,6,7,8
+    #   RUST_BACKTRACE: 1
     networks:
       aleo-devnet:
         ipv4_address: 172.20.0.2
@@ -17,16 +20,19 @@ services:
           - validator0
 
   validator1:
-    image: aleohq/snarkos:latest
+    image: localhost/snarkos:devnet-v4.1.0
     container_name: validator1
-    entrypoint: ["/aleo/bin/snarkos"]
+    entrypoint: ["snarkos"]
     command: [
       "start", "--nodisplay", "--bft", "0.0.0.0:5000", "--node", "0.0.0.0:4130", "--network", "1", "--dev", "1",
-      "--dev-num-validators", "4", "--validator", "--allow-external-peers",
+      "--dev-num-validators", "4", "--validator", "--no-dev-txs", "--allow-external-peers",
       "--peers", "172.20.0.2:4130,172.20.0.4:4130,172.20.0.5:4130,172.20.0.6:4130",
       "--validators", "172.20.0.2:5000,172.20.0.4:5000,172.20.0.5:5000",
-      "--norest"
+      "--norest", "--verbosity", "0"
     ]
+    # environment: 
+    #   CONSENSUS_VERSION_HEIGHTS: 0,1,2,3,4,5,6,7,8
+    #   RUST_BACKTRACE: 1
     networks:
       aleo-devnet:
         ipv4_address: 172.20.0.3
@@ -34,15 +40,18 @@ services:
           - validator1
 
   validator2:
-    image: aleohq/snarkos:latest
+    image: localhost/snarkos:devnet-v4.1.0
     container_name: validator2
-    entrypoint: ["/aleo/bin/snarkos"]
+    entrypoint: ["snarkos"]
+    # environment: 
+    #   CONSENSUS_VERSION_HEIGHTS: 0,1,2,3,4,5,6,7,8
+    #   RUST_BACKTRACE: 1
     command: [
       "start", "--nodisplay", "--bft", "0.0.0.0:5000", "--node", "0.0.0.0:4130", "--network", "1", "--dev", "2",
-      "--dev-num-validators", "4", "--validator", "--allow-external-peers",
+      "--dev-num-validators", "4", "--validator", "--no-dev-txs", "--allow-external-peers",
       "--peers", "172.20.0.2:4130,172.20.0.3:4130,172.20.0.5:4130,172.20.0.6:4130",
       "--validators", "172.20.0.2:5000,172.20.0.3:5000,172.20.0.5:5000",
-      "--norest"
+      "--norest", "--verbosity", "0"
     ]
     networks:
       aleo-devnet:
@@ -51,16 +60,19 @@ services:
           - validator2
 
   validator3:
-    image: aleohq/snarkos:latest
+    image: localhost/snarkos:devnet-v4.1.0
     container_name: validator3
-    entrypoint: ["/aleo/bin/snarkos"]
+    entrypoint: ["snarkos"]
     command: [
       "start", "--nodisplay", "--bft", "0.0.0.0:5000", "--node", "0.0.0.0:4130", "--network", "1", "--dev", "3",
-      "--dev-num-validators", "4", "--validator", "--allow-external-peers",
+      "--dev-num-validators", "4", "--validator", "--no-dev-txs", "--allow-external-peers",
       "--peers", "172.20.0.2:4130,172.20.0.3:4130,172.20.0.4:4130,172.20.0.6:4130",
       "--validators", "172.20.0.2:5000,172.20.0.3:5000,172.20.0.4:5000",
-      "--norest"
+      "--norest", "--verbosity", "0"
     ]
+    # environment: 
+    #   CONSENSUS_VERSION_HEIGHTS: 0,1,2,3,4,5,6,7,8
+    #   RUST_BACKTRACE: 1
     networks:
       aleo-devnet:
         ipv4_address: 172.20.0.5
@@ -68,19 +80,23 @@ services:
           - validator3
 
   client:
-    image: aleohq/snarkos:latest
-    container_name: client
-    entrypoint: ["/aleo/bin/snarkos"]
+    image: localhost/snarkos:devnet-v4.1.0
+    container_name: client0
+    entrypoint: ["snarkos"]
     command: [
       "start", "--client", "--nodisplay", "--node", "0.0.0.0:4130", "--network", "1", "--dev", "4",
       "--dev-num-validators", "4", "--allow-external-peers",
-      "--peers", "172.20.0.2:4130,172.20.0.3:4130,172.20.0.4:4130,172.20.0.5:4130", "--rest", "0.0.0.0:3030"
+      "--peers", "172.20.0.2:4130,172.20.0.3:4130,172.20.0.4:4130,172.20.0.5:4130", "--rest", "0.0.0.0:3030", "--rest-rps", "999999999",
+      "--verbosity", "5"
     ]
+    # environment: 
+    #   CONSENSUS_VERSION_HEIGHTS: 0,1,2,3,4,5,6,7,8
+    #   RUST_BACKTRACE: 1
     networks:
       aleo-devnet:
         ipv4_address: 172.20.0.6
         aliases:
-          - client
+          - client0
     depends_on:
       - validator0
       - validator1

--- a/download-provers.sh
+++ b/download-provers.sh
@@ -13,13 +13,14 @@ cd "$DEST_DIR"
 # List of files to download
 FILES=(
   "powers-of-beta-16.usrs.84631bc"
-  "shifted-powers-of-beta-16.usrs.d99bcb3"
   "powers-of-beta-17.usrs.7c27308"
   "shifted-powers-of-beta-17.usrs.2025178"
   "powers-of-beta-18.usrs.7a12bcb"
   "shifted-powers-of-beta-18.usrs.9a1859e"
   "powers-of-beta-19.usrs.e535d44"
   "shifted-powers-of-beta-19.usrs.662e343"
+  "powers-of-beta-20.usrs.3daad5e"
+  "shifted-powers-of-beta-20.usrs.dbb509d"
 )
 
 # Create a temporary directory to track download status


### PR DESCRIPTION
Support publishing 'aleo-devnet' images with `build-publish-image.sh` script multi-platform builds support and all and updated `README.md`.

- Published [here](https://github.com/sealance-io/aleo-containers/pkgs/container/aleo-devnet/502584522?tag=v3.1.0-v4.1.0)