### PR TITLE
support leo v4

### DIFF
--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -11,7 +11,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v3.5.0-v4.5.4'
+        default: 'v4.0.0-v4.6.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -53,7 +53,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v3.5.0-v4.5.4'
+        default: 'v4.0.0-v4.6.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -143,10 +143,11 @@ jobs:
 
       - name: Setup Leo CLI
         id: setup-leo
+        # TODO: update SHA after sealance-io/setup-leo-action PR #13 (Leo v4 support) merges
         uses: sealance-io/setup-leo-action@126611b39ce92d063c50da6623f8a0b08bf294dd # v1.0.0
         with:
           version: ${{ steps.parse-version.outputs.leo-version }}
-          rust-version: '1.92.0'
+          rust-version: '1.94.1'
           enable-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' && 'always' || 'never' }}
           run-audit: true

--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -29,9 +29,9 @@ on:
         default: false
         type: boolean
       consensus-version:
-        description: 'Target consensus version for devnet (default: 13)'
+        description: 'Target consensus version for devnet (default: 14)'
         required: false
-        default: 13
+        default: 14
         type: number
       required-programs:
         description: 'Comma-separated program IDs to verify. Empty = read from required-programs.txt'
@@ -71,9 +71,9 @@ on:
         default: false
         type: boolean
       consensus-version:
-        description: 'Target consensus version for devnet (default: 13)'
+        description: 'Target consensus version for devnet (default: 14)'
         required: false
-        default: 13
+        default: 14
         type: number
       required-programs:
         description: 'Comma-separated program IDs to verify. Empty = read from required-programs.txt'

--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -11,7 +11,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.0.0-v4.6.0'
+        default: 'v4.0.2-v4.6.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -53,7 +53,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.0.0-v4.6.0'
+        default: 'v4.0.2-v4.6.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'

--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install dokojs CLI
         run: |
-          npm install -g @sealance-io/dokojs@1.0.4 --ignore-scripts
+          npm install -g @sealance-io/dokojs@1.0.8 --registry=https://registry.npmjs.org/ --ignore-scripts
           dokojs --version
 
       - name: Create data directory
@@ -223,7 +223,7 @@ jobs:
           cp .env.example .env
 
           # Install dependencies
-          npm ci
+          npm ci --ignore-scripts
 
           # Apply package patches
           npm run postinstall

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -28,7 +28,7 @@ on:
         default: 'sealance-io'
         type: string
       project_version:
-        description: 'Project version to build (e.g., v4.0.0)'
+        description: 'Project version to build (e.g., v4.0.2)'
         required: true
         type: string
       project_repo:
@@ -213,7 +213,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            LEO_VERSION=${{ inputs.leo_version || 'v4.0.0' }}
+            LEO_VERSION=${{ inputs.leo_version || 'v4.0.2' }}
             SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.6.0' }}
             RUST_VERSION=${{ needs.determine-params.outputs.rust_version }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true,name=${{ needs.determine-params.outputs.registry_image }}

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -28,7 +28,7 @@ on:
         default: 'sealance-io'
         type: string
       project_version:
-        description: 'Project version to build (e.g., v3.5.0)'
+        description: 'Project version to build (e.g., v4.0.0)'
         required: true
         type: string
       project_repo:
@@ -48,7 +48,7 @@ on:
       snarkos_version:
         description: 'snarkOS version for aleo-devnet'
         required: false
-        default: 'v4.5.4'
+        default: 'v4.6.0'
         type: string
       rust_version:
         description: 'Rust version override (inferred from upstream if not set)'
@@ -122,7 +122,7 @@ jobs:
               TAG="${INPUT_PROJECT_VERSION}"
             elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
               REPO_PATH="ProvableHQ/snarkOS"
-              TAG="${INPUT_SNARKOS_VERSION:-v4.5.4}"
+              TAG="${INPUT_SNARKOS_VERSION:-v4.6.0}"
             fi
 
             CHANNEL=$(curl -sSf --max-time 10 \
@@ -134,8 +134,8 @@ jobs:
               echo "rust_version=${CHANNEL}" >> $GITHUB_OUTPUT
               echo "Inferred Rust version: ${CHANNEL}"
             else
-              echo "rust_version=1.92.0" >> $GITHUB_OUTPUT
-              echo "Could not infer Rust version, using default: 1.92.0"
+              echo "rust_version=1.94.1" >> $GITHUB_OUTPUT
+              echo "Could not infer Rust version, using default: 1.94.1"
             fi
           fi
 
@@ -213,8 +213,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            LEO_VERSION=${{ inputs.leo_version || 'v3.5.0' }}
-            SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.5.4' }}
+            LEO_VERSION=${{ inputs.leo_version || 'v4.0.0' }}
+            SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.6.0' }}
             RUST_VERSION=${{ needs.determine-params.outputs.rust_version }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true,name=${{ needs.determine-params.outputs.registry_image }}
           cache-from: type=registry,ref=${{ needs.determine-params.outputs.registry_image }}:cache-${{ matrix.platform_pair }}

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -9,13 +9,13 @@ on:
     # Allow manual trigger for testing
     inputs:
       minimum_leo_version:
-        description: 'Minimum Leo version to build (defaults to v3.5.0)'
+        description: 'Minimum Leo version to build (defaults to v4.0.0)'
         required: false
-        default: 'v3.5.0'
+        default: 'v4.0.0'
       minimum_snarkos_version:
-        description: 'Minimum snarkOS version to build (defaults to v4.5.4)'
+        description: 'Minimum snarkOS version to build (defaults to v4.6.0)'
         required: false
-        default: 'v4.5.4'
+        default: 'v4.6.0'
 
 permissions: {}
 
@@ -36,8 +36,8 @@ jobs:
       - name: Set up variables
         id: vars
         env:
-          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v3.5.0' }}
-          INPUT_MIN_SNARKOS: ${{ inputs.minimum_snarkos_version || 'v4.5.4' }}
+          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v4.0.0' }}
+          INPUT_MIN_SNARKOS: ${{ inputs.minimum_snarkos_version || 'v4.6.0' }}
         run: |
           echo "leo_repo=ProvableHQ/leo" >> $GITHUB_OUTPUT
           echo "snarkos_repo=ProvableHQ/snarkOS" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -9,9 +9,9 @@ on:
     # Allow manual trigger for testing
     inputs:
       minimum_leo_version:
-        description: 'Minimum Leo version to build (defaults to v4.0.0)'
+        description: 'Minimum Leo version to build (defaults to v4.0.2)'
         required: false
-        default: 'v4.0.0'
+        default: 'v4.0.2'
       minimum_snarkos_version:
         description: 'Minimum snarkOS version to build (defaults to v4.6.0)'
         required: false
@@ -36,7 +36,7 @@ jobs:
       - name: Set up variables
         id: vars
         env:
-          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v4.0.0' }}
+          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v4.0.2' }}
           INPUT_MIN_SNARKOS: ${{ inputs.minimum_snarkos_version || 'v4.6.0' }}
         run: |
           echo "leo_repo=ProvableHQ/leo" >> $GITHUB_OUTPUT

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -11,10 +11,10 @@ on:
           - leo-lang
           - aleo-devnet
       leo_version:
-        description: 'Leo version (e.g., v4.0.0)'
+        description: 'Leo version (e.g., v4.0.2)'
         required: true
         type: string
-        default: 'v4.0.0'
+        default: 'v4.0.2'
       snarkos_version:
         description: 'snarkOS version (aleo-devnet only)'
         type: string
@@ -54,7 +54,7 @@ jobs:
             echo "project_version=${LEO_VERSION}" >> $GITHUB_OUTPUT
           elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
             echo "dockerfile=aleo-devnet.Dockerfile" >> $GITHUB_OUTPUT
-            # For aleo-devnet, project_version is combined: v4.0.0-v4.6.0
+            # For aleo-devnet, project_version is combined: v4.0.2-v4.6.0
             echo "project_version=${LEO_VERSION}-${SNARKOS_VERSION}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -11,14 +11,14 @@ on:
           - leo-lang
           - aleo-devnet
       leo_version:
-        description: 'Leo version (e.g., v3.5.0)'
+        description: 'Leo version (e.g., v4.0.0)'
         required: true
         type: string
-        default: 'v3.5.0'
+        default: 'v4.0.0'
       snarkos_version:
         description: 'snarkOS version (aleo-devnet only)'
         type: string
-        default: 'v4.5.4'
+        default: 'v4.6.0'
         required: false
       tag_latest:
         description: 'Tag as latest'
@@ -46,7 +46,7 @@ jobs:
         run: |
           LEO_VERSION="${INPUT_LEO_VERSION}"
           SNARKOS_VERSION="${INPUT_SNARKOS_VERSION}"
-          SNARKOS_VERSION="${SNARKOS_VERSION:-v4.5.4}"
+          SNARKOS_VERSION="${SNARKOS_VERSION:-v4.6.0}"
 
           if [[ "${INPUT_IMAGE_NAME}" == "leo-lang" ]]; then
             echo "dockerfile=leo.Dockerfile" >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
             echo "project_version=${LEO_VERSION}" >> $GITHUB_OUTPUT
           elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
             echo "dockerfile=aleo-devnet.Dockerfile" >> $GITHUB_OUTPUT
-            # For aleo-devnet, project_version is combined: v3.5.0-v4.5.4
+            # For aleo-devnet, project_version is combined: v4.0.0-v4.6.0
             echo "project_version=${LEO_VERSION}-${SNARKOS_VERSION}" >> $GITHUB_OUTPUT
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,14 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 
 ```bash
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
-./build-publish-deployment-snapshot.sh --commit main --version v4.0.0-v4.6.0 --consensus-version 13
+./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0 --consensus-version 13
 ```
 
 ### Run Containers
 
 ```bash
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0 leo --help
-docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2 leo --help
+docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0
 curl http://localhost:3030/testnet/latest/height
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 
 ```bash
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
-./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0 --consensus-version 13
+./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0 --consensus-version 14
 ```
 
 ### Run Containers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,14 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 
 ```bash
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
-./build-publish-deployment-snapshot.sh --commit main --version v3.5.0-v4.5.4 --consensus-version 13
+./build-publish-deployment-snapshot.sh --commit main --version v4.0.0-v4.6.0 --consensus-version 13
 ```
 
 ### Run Containers
 
 ```bash
-docker run --rm ghcr.io/sealance-io/leo-lang:v3.5.0 leo --help
-docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0 leo --help
+docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0
 curl http://localhost:3030/testnet/latest/height
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,101 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Primary Reference
+## What This Is
 
-All repository context, conventions, and architecture documentation lives in [AGENTS.md](AGENTS.md).
-Read that file first. It contains an index to deep-dive docs under `docs/` — load those on demand
-when working on the relevant subsystem.
+Multi-arch (AMD64/ARM64) Docker images for the Aleo blockchain ecosystem, published to `ghcr.io/sealance-io/`. Two image variants: **leo-lang** (Leo CLI + Node.js) and **aleo-devnet** (Leo + snarkOS for local test networks).
 
-## Claude-Specific Instructions
+## Image Dependency Chain
+
+```
+leo.Dockerfile → ghcr.io/sealance-io/leo-lang:vX.Y.Z
+                        ↓ (COPY --from)
+aleo-devnet.Dockerfile → ghcr.io/sealance-io/aleo-devnet:vX.Y.Z-vA.B.C
+                                ↓ (FROM base, no CMD override)
+snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
+```
+
+**Build order matters**: `leo-lang` must be built/published before `aleo-devnet`.
+
+## Essential Commands
+
+```bash
+# Build leo-lang locally (single arch, fastest)
+./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --local-arch --no-push
+
+# Build aleo-devnet locally (requires leo-lang image)
+./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --local-arch --no-push
+
+# Build deployment snapshot
+./build-publish-deployment-snapshot.sh --commit main --skip-push
+
+# Lint (required before completing any task)
+shellcheck --severity=warning *.sh
+hadolint leo.Dockerfile
+hadolint aleo-devnet.Dockerfile
+```
+
+## Validation Rules
 
 - When modifying shell scripts, validate with `shellcheck --severity=warning` before considering the task complete.
 - When modifying Dockerfiles, validate with `hadolint` before considering the task complete.
 - When modifying GitHub Actions workflows, verify SHA-pinned action references include a trailing version comment (e.g., `# v6.0.2`).
+
+## Architecture
+
+### Leo v3/v4 Dual Layout Support
+
+`leo.Dockerfile` auto-detects Leo's workspace layout at build time:
+- **Leo v4+**: Workspace with `crates/leo/Cargo.toml` — builds with `cargo build --release --locked -p leo-lang`
+- **Leo v3**: Single-crate root — builds with `cargo build --release --locked`
+
+Both produce the same `target/release/leo` binary. The detection is in the builder stage's `RUN` command.
+
+### Multi-Stage Builds with cargo-chef
+
+Both Dockerfiles use [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) for dependency caching:
+1. **Planner**: clones repo, extracts `rust-toolchain.toml`, generates `recipe.json`
+2. **Builder**: cooks dependencies (cached layer), then compiles source
+3. **Runtime**: minimal image with binaries and non-root `leo` user (UID 1001)
+
+### Rust Toolchain Version Handling
+
+Two layers work together:
+1. **Build-time inference**: `infer_rust_version()` in the build script (and CI) fetches upstream `rust-toolchain.toml` to set the Docker base image tag. Falls back to `1.94.1`.
+2. **Dockerfile-level**: The actual compiler is determined by `rust-toolchain.toml` copied from the cloned repo. The base image just needs `rustup`.
+
+`RUST_VERSION` is auto-inferred — only override explicitly.
+
+### Devnet Entrypoint Three-Way Branching
+
+`devnet-entrypoint.sh` has three modes based on args:
+- **No args** (`docker run <image>`): builds `leo devnet` from env vars (`STORAGE`, `VERBOSITY`, `NUM_VALIDATORS`, etc.)
+- **`devnet` args** (`docker run <image> devnet --custom`): passes through with log forwarding
+- **Non-devnet** (`docker run <image> new my_project`): `exec leo` passthrough (no wrapper)
+
+## Key Gotchas
+
+- **Version format**: Devnet tags are strictly `vX.Y.Z-vA.B.C` (Leo-snarkOS)
+- **Minimum versions**: Leo >= v3.5.0, snarkOS >= v4.5.3 (validation guards in scripts and CI protect against pre-rootless base images)
+- **Hadolint ignores**: `.hadolint.yaml` ignores DL3008 and DL3059 intentionally — do not remove
+- **Fail-closed policy**: Publish flows require a non-empty program list from `required-programs.txt`
+- **snarkOS features**: Build uses `default,snarkos-node-metrics,test_network` — `test_network` is required for devnet
+
+### CI Hardening (maintain when editing workflows)
+
+- **SHA-pinned actions**: All `uses:` reference full commit SHAs, not mutable tags — include version as trailing comment
+- **`persist-credentials: false`**: Required on all `actions/checkout` steps
+- **Minimal permissions**: `permissions: {}` at workflow level, explicit per-job grants
+- **Env indirection**: Never interpolate `github.*`/`inputs.*` directly in `run:` scripts — pass through `env:` blocks
+- **Job-level change detection**: CI uses job-level (not workflow-level `paths`) to avoid stuck required checks on unrelated PRs
+
+## Deep-Dive Reference
+
+Load these on demand when working on the corresponding subsystem:
+
+| When working on... | Read |
+|---|---|
+| Dockerfiles, multi-stage builds, Rust toolchain | [docs/architecture.md](docs/architecture.md) |
+| Entrypoint, devnet env vars, snapshots, validation | [docs/devnet.md](docs/devnet.md) |
+| Build scripts, flags, env customization | [docs/building.md](docs/building.md) |
+| CI workflows, GitHub Actions, security | [docs/CI.md](docs/CI.md) |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository provides multi-architecture (AMD64/ARM64) Docker images for Aleo
 
 Pre-built images are available on GitHub Container Registry:
 
-- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.0.0`
-- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0`
+- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.0.2`
+- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0`
 
 ### Custom Deployment Snapshots
 - **With deployed programs**: `ghcr.io/sealance-io/aleo-devnet-custom:latest`
@@ -22,13 +22,13 @@ You can also use the `latest` tag to always get the most recent version.
 ### Image Contents
 
 #### Leo Lang (`leo-lang`)
-- Leo CLI v4.0.0
+- Leo CLI v4.0.2
 - Node.js v24
 - Debian trixie (slim)
 - Essential SSL libraries
 
 #### Aleo Devnet Image (`aleo-devnet`)
-- Leo CLI v4.0.0
+- Leo CLI v4.0.2
 - snarkOS v4.6.0
 - Pre-downloaded mainnet prover parameters (~2GB)
 - Debian trixie (slim)
@@ -43,16 +43,16 @@ For development, deployment, and running Leo applications:
 
 ```bash
 # Run the Leo CLI directly
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0 leo --help
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2 leo --help
 
 # Check installed versions
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2
 
 # Mount your project directory and work with Leo
-docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.0 leo build
+docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.2 leo build
 
 # Start a shell in the container
-docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.0 /bin/bash
+docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.2 /bin/bash
 ```
 
 ### Aleo Devnet Image
@@ -63,25 +63,25 @@ For running a local Aleo development network with Leo and snarkOS:
 # Run a minimal devnet (4 validators + 1 client)
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0
+  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0
 
 # Run with custom devnet parameters
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
   devnet --storage /aleo/data --clear-storage --yes \
   --verbosity 4 --num-validators 4 --num-clients 2
 
 # Run snarkOS directly instead of Leo devnet command
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   --entrypoint ./snarkos \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
   start --client --nodisplay --node 0.0.0.0:4130 \
   --network 1 --dev 0 --rest 0.0.0.0:3030
 
 # Access Leo CLI for development
 docker run -it --rm -v $(pwd):/app -w /app \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
   new my_project
 ```
 #### GitHub Actions Example
@@ -107,7 +107,7 @@ jobs:
         # TODO: update SHA after sealance-io/setup-leo-action PR #13 (Leo v4 support) merges
         uses: sealance-io/setup-leo-action@126611b39ce92d063c50da6623f8a0b08bf294dd # v1.0.0
         with:
-          version: '4.0.0'
+          version: '4.0.2'
 
       - name: Build Leo project
         run: leo build
@@ -178,10 +178,10 @@ The repository includes a script to create custom Aleo devnet images with pre-de
 ./build-publish-deployment-snapshot.sh --commit abc1234 --skip-push
 
 # Build with custom base image version
-./build-publish-deployment-snapshot.sh --version v4.0.0-v4.6.0 --skip-push
+./build-publish-deployment-snapshot.sh --version v4.0.2-v4.6.0 --skip-push
 
 # Build and push to registry (requires authentication)
-./build-publish-deployment-snapshot.sh --commit main --version v4.0.0-v4.6.0
+./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0
 
 # Override required programs for verification (default: from required-programs.txt)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push --required-programs "merkle_tree.aleo,custom.aleo"
@@ -219,18 +219,18 @@ The `--variant` flag allows you to add a suffix to version tags (not `latest`), 
 ```bash
 # Build Leo with Node.js 24
 NODE_VERSION=24 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --variant node24
-# Produces: leo-lang:v4.0.0-node24, leo-lang:latest
+# Produces: leo-lang:v4.0.2-node24, leo-lang:latest
 
 # Build with custom Rust version
 RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --variant rust189
-# Produces: aleo-devnet:v4.0.0-v4.6.0-rust189, aleo-devnet:latest
+# Produces: aleo-devnet:v4.0.2-v4.6.0-rust189, aleo-devnet:latest
 ```
 
 ### Environment Variables
 
 | Variable | Applies to | Description |
 |---|---|---|
-| `LEO_VERSION` | both | Leo release tag (default: `v4.0.0`) |
+| `LEO_VERSION` | both | Leo release tag (default: `v4.0.2`) |
 | `SNARKOS_VERSION` | aleo-devnet | snarkOS release tag (default: `v4.6.0`) |
 | `LEO_REPO` | both | Leo Git URL (default: ProvableHQ/leo) |
 | `RUST_VERSION` | both | Rust base image tag (auto-inferred from upstream `rust-toolchain.toml`) |
@@ -240,7 +240,7 @@ RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.0.0" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
+LEO_VERSION="v4.0.2" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 ```
 
@@ -271,7 +271,7 @@ echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 Add the appropriate user permissions:
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.0.0 leo build
+docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.0.2 leo build
 ```
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository provides multi-architecture (AMD64/ARM64) Docker images for Aleo
 
 Pre-built images are available on GitHub Container Registry:
 
-- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v3.5.0`
-- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4`
+- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.0.0`
+- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0`
 
 ### Custom Deployment Snapshots
 - **With deployed programs**: `ghcr.io/sealance-io/aleo-devnet-custom:latest`
@@ -22,14 +22,14 @@ You can also use the `latest` tag to always get the most recent version.
 ### Image Contents
 
 #### Leo Lang (`leo-lang`)
-- Leo CLI v3.5.0
+- Leo CLI v4.0.0
 - Node.js v24
 - Debian trixie (slim)
 - Essential SSL libraries
 
 #### Aleo Devnet Image (`aleo-devnet`)
-- Leo CLI v3.5.0
-- snarkOS v4.5.4
+- Leo CLI v4.0.0
+- snarkOS v4.6.0
 - Pre-downloaded mainnet prover parameters (~2GB)
 - Debian trixie (slim)
 - Essential runtime libraries
@@ -43,45 +43,45 @@ For development, deployment, and running Leo applications:
 
 ```bash
 # Run the Leo CLI directly
-docker run --rm ghcr.io/sealance-io/leo-lang:v3.5.0 leo --help
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0 leo --help
 
 # Check installed versions
-docker run --rm ghcr.io/sealance-io/leo-lang:v3.5.0
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.0
 
 # Mount your project directory and work with Leo
-docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v3.5.0 leo build
+docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.0 leo build
 
 # Start a shell in the container
-docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v3.5.0 /bin/bash
+docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.0 /bin/bash
 ```
 
 ### Aleo Devnet Image
 
-For running a local Aleo development network with Leo v3 and snarkOS:
+For running a local Aleo development network with Leo and snarkOS:
 
 ```bash
 # Run a minimal devnet (4 validators + 1 client)
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4
+  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0
 
 # Run with custom devnet parameters
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
   devnet --storage /aleo/data --clear-storage --yes \
   --verbosity 4 --num-validators 4 --num-clients 2
 
 # Run snarkOS directly instead of Leo devnet command
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   --entrypoint ./snarkos \
-  ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
   start --client --nodisplay --node 0.0.0.0:4130 \
   --network 1 --dev 0 --rest 0.0.0.0:3030
 
 # Access Leo CLI for development
 docker run -it --rm -v $(pwd):/app -w /app \
-  ghcr.io/sealance-io/aleo-devnet:v3.5.0-v4.5.4 \
+  ghcr.io/sealance-io/aleo-devnet:v4.0.0-v4.6.0 \
   new my_project
 ```
 #### GitHub Actions Example
@@ -104,9 +104,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Leo CLI
+        # TODO: update SHA after sealance-io/setup-leo-action PR #13 (Leo v4 support) merges
         uses: sealance-io/setup-leo-action@126611b39ce92d063c50da6623f8a0b08bf294dd # v1.0.0
         with:
-          version: '3.5.0'
+          version: '4.0.0'
 
       - name: Build Leo project
         run: leo build
@@ -177,10 +178,10 @@ The repository includes a script to create custom Aleo devnet images with pre-de
 ./build-publish-deployment-snapshot.sh --commit abc1234 --skip-push
 
 # Build with custom base image version
-./build-publish-deployment-snapshot.sh --version v3.5.0-v4.5.4 --skip-push
+./build-publish-deployment-snapshot.sh --version v4.0.0-v4.6.0 --skip-push
 
 # Build and push to registry (requires authentication)
-./build-publish-deployment-snapshot.sh --commit main --version v3.5.0-v4.5.4
+./build-publish-deployment-snapshot.sh --commit main --version v4.0.0-v4.6.0
 
 # Override required programs for verification (default: from required-programs.txt)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push --required-programs "merkle_tree.aleo,custom.aleo"
@@ -218,19 +219,19 @@ The `--variant` flag allows you to add a suffix to version tags (not `latest`), 
 ```bash
 # Build Leo with Node.js 24
 NODE_VERSION=24 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --variant node24
-# Produces: leo-lang:v3.5.0-node24, leo-lang:latest
+# Produces: leo-lang:v4.0.0-node24, leo-lang:latest
 
 # Build with custom Rust version
 RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --variant rust189
-# Produces: aleo-devnet:v3.5.0-v4.5.4-rust189, aleo-devnet:latest
+# Produces: aleo-devnet:v4.0.0-v4.6.0-rust189, aleo-devnet:latest
 ```
 
 ### Environment Variables
 
 | Variable | Applies to | Description |
 |---|---|---|
-| `LEO_VERSION` | both | Leo release tag (default: `v3.5.0`) |
-| `SNARKOS_VERSION` | aleo-devnet | snarkOS release tag (default: `v4.5.4`) |
+| `LEO_VERSION` | both | Leo release tag (default: `v4.0.0`) |
+| `SNARKOS_VERSION` | aleo-devnet | snarkOS release tag (default: `v4.6.0`) |
 | `LEO_REPO` | both | Leo Git URL (default: ProvableHQ/leo) |
 | `RUST_VERSION` | both | Rust base image tag (auto-inferred from upstream `rust-toolchain.toml`) |
 | `NODE_VERSION` | leo-lang | Node.js major version (default: `24`) |
@@ -239,7 +240,7 @@ RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v3.5.0" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
+LEO_VERSION="v4.0.0" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 ```
 
@@ -270,7 +271,7 @@ echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 Add the appropriate user permissions:
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v3.5.0 leo build
+docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.0.0 leo build
 ```
 
 ## 📜 License

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -3,10 +3,10 @@
 # Run: docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data aleo-devnet
 
 # Build arguments
-ARG LEO_VERSION=v3.5.0
-ARG SNARKOS_VERSION=v4.5.4
+ARG LEO_VERSION=v4.0.0
+ARG SNARKOS_VERSION=v4.6.0
 # Used to pin Rust base images.
-ARG RUST_VERSION=1.92.0
+ARG RUST_VERSION=1.88.0
 
 # =============================================================================
 # Stage 0: Leo image reference (workaround for --from not supporting ARG)

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -3,7 +3,7 @@
 # Run: docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data aleo-devnet
 
 # Build arguments
-ARG LEO_VERSION=v4.0.0
+ARG LEO_VERSION=v4.0.2
 ARG SNARKOS_VERSION=v4.6.0
 # Used to pin Rust base images.
 ARG RUST_VERSION=1.88.0

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -39,15 +39,15 @@ usage() {
     echo ""
     echo "Options:"
     echo "  -c, --commit <sha/branch/tag>    Git commit SHA, branch, or tag to clone (default: main)"
-    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.0.0-v4.6.0)"
+    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.0.2-v4.6.0)"
     echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 13)"
     echo "  -p, --required-programs <list>   Comma-separated program IDs to verify (default: from required-programs.txt)"
     echo "  --skip-push                      Build images but skip pushing to registry (for testing)"
     echo "  -h, --help                       Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                               # Use defaults (main branch, v4.0.0-v4.6.0)"
-    echo "  $0 -c develop -v v4.0.0-v4.6.0   # Use develop branch and v4.0.0-v4.6.0 image"
+    echo "  $0                               # Use defaults (main branch, v4.0.2-v4.6.0)"
+    echo "  $0 -c develop -v v4.0.2-v4.6.0   # Use develop branch and v4.0.2-v4.6.0 image"
     echo "  $0 --commit abc1234 --version latest"
     echo "  $0 --skip-push                   # Build locally without pushing"
     echo "  $0 -t 15                         # Use consensus version 15"
@@ -63,7 +63,7 @@ usage() {
 
 # Parse command line arguments
 GIT_REF="main"
-DEVNET_VERSION="v4.0.0-v4.6.0"
+DEVNET_VERSION="v4.0.2-v4.6.0"
 CONSENSUS_VERSION=13
 SKIP_PUSH=false
 REQUIRED_PROGRAMS=""

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -341,6 +341,17 @@ fi
 # Display npm version for debugging
 print_step "Using npm version: $(npm --version)"
 
+print_step "Installing dokojs CLI from npmjs registry..."
+if ! npm install -g @sealance-io/dokojs@1.0.8 --registry=https://registry.npmjs.org/ --ignore-scripts; then
+    print_error "Failed to install @sealance-io/dokojs@1.0.8 from npmjs registry."
+    exit 1
+fi
+if ! command -v dokojs &> /dev/null; then
+    print_error "dokojs command not found after installation."
+    exit 1
+fi
+print_success "dokojs installed: $(dokojs --version)"
+
 # Step 2: Pull aleo-devnet image
 print_step "Pulling image ${DEVNET_IMAGE}..."
 ${CONTAINER_TOOL} pull "${DEVNET_IMAGE}"
@@ -373,13 +384,6 @@ if ! npm run build --workspace=@sealance-io/policy-engine-aleo; then
     exit 1
 fi
 print_success "@sealance-io/policy-engine-aleo installed."
-
-# Check if dokojs is available globally
-if ! command -v dokojs &> /dev/null; then
-    print_warning "dokojs command not found in PATH."
-    print_warning "The compile step might fail if dokojs is not installed."
-    print_warning "Please ensure dokojs is installed globally via npm."
-fi
 
 print_step "Compiling project (rimraf artifacts && dokojs compile)..."
 if ! TESTNET_ENDPOINT="https://api.explorer.provable.com/v1" npm run compile; then

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -39,15 +39,15 @@ usage() {
     echo ""
     echo "Options:"
     echo "  -c, --commit <sha/branch/tag>    Git commit SHA, branch, or tag to clone (default: main)"
-    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v3.5.0-v4.5.4)"
+    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.0.0-v4.6.0)"
     echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 13)"
     echo "  -p, --required-programs <list>   Comma-separated program IDs to verify (default: from required-programs.txt)"
     echo "  --skip-push                      Build images but skip pushing to registry (for testing)"
     echo "  -h, --help                       Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                               # Use defaults (main branch, v3.5.0-v4.5.4)"
-    echo "  $0 -c develop -v v3.5.0-v4.5.4   # Use develop branch and v3.5.0-v4.5.4 image"
+    echo "  $0                               # Use defaults (main branch, v4.0.0-v4.6.0)"
+    echo "  $0 -c develop -v v4.0.0-v4.6.0   # Use develop branch and v4.0.0-v4.6.0 image"
     echo "  $0 --commit abc1234 --version latest"
     echo "  $0 --skip-push                   # Build locally without pushing"
     echo "  $0 -t 15                         # Use consensus version 15"
@@ -63,7 +63,7 @@ usage() {
 
 # Parse command line arguments
 GIT_REF="main"
-DEVNET_VERSION="v3.5.0-v4.5.4"
+DEVNET_VERSION="v4.0.0-v4.6.0"
 CONSENSUS_VERSION=13
 SKIP_PUSH=false
 REQUIRED_PROGRAMS=""

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -40,7 +40,7 @@ usage() {
     echo "Options:"
     echo "  -c, --commit <sha/branch/tag>    Git commit SHA, branch, or tag to clone (default: main)"
     echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.0.2-v4.6.0)"
-    echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 13)"
+    echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 14)"
     echo "  -p, --required-programs <list>   Comma-separated program IDs to verify (default: from required-programs.txt)"
     echo "  --skip-push                      Build images but skip pushing to registry (for testing)"
     echo "  -h, --help                       Show this help message"
@@ -64,7 +64,7 @@ usage() {
 # Parse command line arguments
 GIT_REF="main"
 DEVNET_VERSION="v4.0.2-v4.6.0"
-CONSENSUS_VERSION=13
+CONSENSUS_VERSION=14
 SKIP_PUSH=false
 REQUIRED_PROGRAMS=""
 

--- a/build-publish-image.sh
+++ b/build-publish-image.sh
@@ -199,7 +199,7 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Examples:"
       echo "  $0 --dockerfile leo.Dockerfile --image-name leo-lang --variant node24"
-      echo "  # Produces: leo-lang:v3.5.0-node24, leo-lang:latest"
+      echo "  # Produces: leo-lang:v4.0.0-node24, leo-lang:latest"
       exit 0
       ;;
     *)
@@ -211,14 +211,14 @@ done
 
 # Set project-specific version variables based on image name
 if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
-  PROJECT_VERSION=${LEO_VERSION:-"v3.5.0"}
+  PROJECT_VERSION=${LEO_VERSION:-"v4.0.0"}
   PROJECT_VERSION_ARG="LEO_VERSION"
   PROJECT_REPO=${LEO_REPO:-"https://github.com/ProvableHQ/leo"}
   PROJECT_REPO_ARG="LEO_REPO"
 elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
   # Aleo-devnet uses both LEO and SNARKOS versions
-  LEO_VERSION=${LEO_VERSION:-"v3.5.0"}
-  SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.5.4"}
+  LEO_VERSION=${LEO_VERSION:-"v4.0.0"}
+  SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.6.0"}
   PROJECT_VERSION="${LEO_VERSION}-${SNARKOS_VERSION}"
   # For aleo-devnet, we'll pass both versions as build args
   PROJECT_VERSION_ARG="LEO_VERSION"
@@ -241,7 +241,7 @@ if [[ -z "${RUST_VERSION:-}" ]]; then
     RUST_VERSION="$INFERRED_RUST"
     echo "Inferred Rust toolchain version: $RUST_VERSION (from upstream rust-toolchain.toml)"
   else
-    RUST_VERSION="1.92.0"
+    RUST_VERSION="1.94.1"
     echo "Could not infer Rust version, using default: $RUST_VERSION"
   fi
 fi

--- a/build-publish-image.sh
+++ b/build-publish-image.sh
@@ -128,7 +128,7 @@ retry_command() {
 # Falls back silently if fetching or parsing fails
 infer_rust_version() {
   local repo_url="$1"  # e.g., https://github.com/ProvableHQ/leo
-  local tag="$2"       # e.g., v3.5.0
+  local tag="$2"       # e.g., v4.0.2
 
   # Extract org/repo from GitHub URL (strip prefix and trailing .git)
   local repo_path
@@ -199,7 +199,7 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Examples:"
       echo "  $0 --dockerfile leo.Dockerfile --image-name leo-lang --variant node24"
-      echo "  # Produces: leo-lang:v4.0.0-node24, leo-lang:latest"
+      echo "  # Produces: leo-lang:v4.0.2-node24, leo-lang:latest"
       exit 0
       ;;
     *)
@@ -211,13 +211,13 @@ done
 
 # Set project-specific version variables based on image name
 if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
-  PROJECT_VERSION=${LEO_VERSION:-"v4.0.0"}
+  PROJECT_VERSION=${LEO_VERSION:-"v4.0.2"}
   PROJECT_VERSION_ARG="LEO_VERSION"
   PROJECT_REPO=${LEO_REPO:-"https://github.com/ProvableHQ/leo"}
   PROJECT_REPO_ARG="LEO_REPO"
 elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
   # Aleo-devnet uses both LEO and SNARKOS versions
-  LEO_VERSION=${LEO_VERSION:-"v4.0.0"}
+  LEO_VERSION=${LEO_VERSION:-"v4.0.2"}
   SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.6.0"}
   PROJECT_VERSION="${LEO_VERSION}-${SNARKOS_VERSION}"
   # For aleo-devnet, we'll pass both versions as build args

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -152,7 +152,7 @@ gh workflow run check-updates.yml
 1. The workflow clones the compliant-transfer-aleo repository at the specified ref
 2. Resolves required programs from `required-programs.txt` (or the `required-programs` input override). Publish flows fail if the list is empty.
 3. Starts an Aleo devnet container with volume mounted at `/aleo/data` (only ledger state)
-4. Waits for the devnet consensus version to reach the target (default: >= 13)
+4. Waits for the devnet consensus version to reach the target (default: >= 14)
 5. Installs dependencies and builds the programs
 6. Deploys the programs to the local devnet
 7. **Pre-shutdown verification**: Queries the REST API for each required program (retries up to 10x)

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -111,7 +111,7 @@ Each architecture builds and pushes by content digest, then a merge job creates 
 
 ```
 build-standard (amd64) ──→ push @sha256:abc...  ─┐
-                                                  ├─→ merge-standard ──→ tag: v4.0.0
+                                                  ├─→ merge-standard ──→ tag: v4.0.2
 build-standard (arm64) ──→ push @sha256:def...  ─┘
 ```
 
@@ -123,14 +123,14 @@ Trigger builds via GitHub Actions UI or the `gh` CLI:
 
 ```bash
 # Build a leo-lang image
-gh workflow run manual-build.yml -f image_name=leo-lang -f leo_version=v4.0.0
+gh workflow run manual-build.yml -f image_name=leo-lang -f leo_version=v4.0.2
 
 # Build an aleo-devnet image
-gh workflow run manual-build.yml -f image_name=aleo-devnet -f leo_version=v4.0.0 -f snarkos_version=v4.6.0
+gh workflow run manual-build.yml -f image_name=aleo-devnet -f leo_version=v4.0.2 -f snarkos_version=v4.6.0
 
 # Build a deployment snapshot
 gh workflow run build-publish-deployment-snapshot.yml \
-  -f git-ref=main -f aleo-devnet-version=v4.0.0-v4.6.0
+  -f git-ref=main -f aleo-devnet-version=v4.0.2-v4.6.0
 
 # Check for upstream version updates
 gh workflow run check-updates.yml

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -111,7 +111,7 @@ Each architecture builds and pushes by content digest, then a merge job creates 
 
 ```
 build-standard (amd64) ──→ push @sha256:abc...  ─┐
-                                                  ├─→ merge-standard ──→ tag: v3.5.0
+                                                  ├─→ merge-standard ──→ tag: v4.0.0
 build-standard (arm64) ──→ push @sha256:def...  ─┘
 ```
 
@@ -123,14 +123,14 @@ Trigger builds via GitHub Actions UI or the `gh` CLI:
 
 ```bash
 # Build a leo-lang image
-gh workflow run manual-build.yml -f image_name=leo-lang -f leo_version=v3.5.0
+gh workflow run manual-build.yml -f image_name=leo-lang -f leo_version=v4.0.0
 
 # Build an aleo-devnet image
-gh workflow run manual-build.yml -f image_name=aleo-devnet -f leo_version=v3.5.0 -f snarkos_version=v4.5.4
+gh workflow run manual-build.yml -f image_name=aleo-devnet -f leo_version=v4.0.0 -f snarkos_version=v4.6.0
 
 # Build a deployment snapshot
 gh workflow run build-publish-deployment-snapshot.yml \
-  -f git-ref=main -f aleo-devnet-version=v3.5.0-v4.5.4
+  -f git-ref=main -f aleo-devnet-version=v4.0.0-v4.6.0
 
 # Check for upstream version updates
 gh workflow run check-updates.yml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Prover download and entrypoint script execution happen as `leo` user. The UID is
 
 Two layers of Rust version management work together:
 
-1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Falls back to `1.92.0` if inference fails or the channel is nightly.
+1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Falls back to `1.94.1` if inference fails or the channel is nightly.
 
 2. **Dockerfile-level deferral**: The actual Rust compiler used is determined by the upstream `rust-toolchain.toml` copied from the cloned repo during the planner stage. The base image just needs `rustup` to install the required toolchain.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -30,8 +30,8 @@
 
 | Variable | Applies to | Default | Description |
 |---|---|---|---|
-| `LEO_VERSION` | both | `v3.5.0` | Leo release tag |
-| `SNARKOS_VERSION` | aleo-devnet | `v4.5.4` | snarkOS release tag |
+| `LEO_VERSION` | both | `v4.0.0` | Leo release tag |
+| `SNARKOS_VERSION` | aleo-devnet | `v4.6.0` | snarkOS release tag |
 | `LEO_REPO` | both | ProvableHQ/leo | Leo Git URL |
 | `RUST_VERSION` | both | auto-inferred | Rust base image tag |
 | `NODE_VERSION` | leo-lang | `24` | Node.js major version |
@@ -40,7 +40,7 @@
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v3.5.0" SNARKOS_VERSION="v4.5.4" \
+LEO_VERSION="v4.0.0" SNARKOS_VERSION="v4.6.0" \
   ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Build from a fork

--- a/docs/building.md
+++ b/docs/building.md
@@ -30,7 +30,7 @@
 
 | Variable | Applies to | Default | Description |
 |---|---|---|---|
-| `LEO_VERSION` | both | `v4.0.0` | Leo release tag |
+| `LEO_VERSION` | both | `v4.0.2` | Leo release tag |
 | `SNARKOS_VERSION` | aleo-devnet | `v4.6.0` | snarkOS release tag |
 | `LEO_REPO` | both | ProvableHQ/leo | Leo Git URL |
 | `RUST_VERSION` | both | auto-inferred | Rust base image tag |
@@ -40,7 +40,7 @@
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.0.0" SNARKOS_VERSION="v4.6.0" \
+LEO_VERSION="v4.0.2" SNARKOS_VERSION="v4.6.0" \
   ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Build from a fork

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -10,7 +10,7 @@ ARG RUST_VERSION=1.94.1
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as planner
 
-ARG LEO_VERSION=v4.0.0
+ARG LEO_VERSION=v4.0.2
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Install cargo-chef and git
@@ -35,7 +35,7 @@ RUN cp rust-toolchain.toml /app/rust-toolchain.toml \
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as builder
 
-ARG LEO_VERSION=v4.0.0
+ARG LEO_VERSION=v4.0.2
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Force rust to use external Git instead of the internal libgit wrapper

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -3,14 +3,14 @@
 ARG NODE_VERSION=24
 ARG DEBIAN_RELEASE=trixie
 # Used to pin Rust base images.
-ARG RUST_VERSION=1.92.0
+ARG RUST_VERSION=1.94.1
 
 # =============================================================================
 # Stage 0: Planner - Generate cargo-chef recipe for dependency caching
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as planner
 
-ARG LEO_VERSION=v3.5.0
+ARG LEO_VERSION=v4.0.0
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Install cargo-chef and git
@@ -35,7 +35,7 @@ RUN cp rust-toolchain.toml /app/rust-toolchain.toml \
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as builder
 
-ARG LEO_VERSION=v3.5.0
+ARG LEO_VERSION=v4.0.0
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Force rust to use external Git instead of the internal libgit wrapper
@@ -64,8 +64,14 @@ RUN git clone -b "${LEO_VERSION}" --recurse-submodules --single-branch --depth 1
 WORKDIR /src/leo
 
 # Compile with optimizations - dependencies already compiled from cargo chef cook
+# Leo v4+ uses a workspace layout (crates/leo/Cargo.toml) requiring -p leo-lang;
+# Leo v3 builds from the workspace root without -p.
 RUN cp /app/rust-toolchain.toml /src/leo/rust-toolchain.toml \
-    && cargo build --release --locked \
+    && if [ -f crates/leo/Cargo.toml ]; then \
+         cargo build --release --locked -p leo-lang; \
+       else \
+         cargo build --release --locked; \
+       fi \
     && cp target/release/leo /usr/local/bin/leo \
     && strip /usr/local/bin/leo
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Add Leo v4.0.0 + snarkOS v4.6.0 support with auto-detection of Leo's new workspace layout (`crates/leo/Cargo.toml` → `cargo build -p leo-lang`), maintaining backward compatibility with Leo v3                  
  - Bump all version defaults across Dockerfiles, build scripts, CI workflows, and documentation (Leo v3.5.0→v4.0.0, snarkOS v4.5.4→v4.6.0, Rust 1.92.0→1.94.1/1.88.0)                                               
  - Enrich CLAUDE.md from a stub into a self-contained project reference                                                                                                                                             
                                                                                                                                                                                                                   
  ## Key changes                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  **`leo.Dockerfile`** — the critical build change:                                                                                                                                                                  
   
  ```dockerfile                                                                                                                                                                                                      
  # Auto-detect Leo v4 workspace layout vs v3 single-crate root                                                                                                                                                    
  RUN if [ -f crates/leo/Cargo.toml ]; then \
        cargo build --release --locked -p leo-lang; \
      else \                                                                                                                                                                                                         
        cargo build --release --locked; \
      fi                                                                                                                                                                                                             
                                                                                                                                                                                                                   
  Version matrix:

  ┌────────────────────┬────────┬────────┐
  │                    │ Before │ After  │
  ├────────────────────┼────────┼────────┤
  │ Leo                │ v3.5.0 │ v4.0.0 │
  ├────────────────────┼────────┼────────┤
  │ snarkOS            │ v4.5.4 │ v4.6.0 │
  ├────────────────────┼────────┼────────┤                                                                                                                                                                           
  │ Rust (leo-lang)    │ 1.92.0 │ 1.94.1 │
  ├────────────────────┼────────┼────────┤                                                                                                                                                                           
  │ Rust (aleo-devnet) │ 1.92.0 │ 1.88.0 │                                                                                                                                                                         
  └────────────────────┴────────┴────────┘                                                                                                                                                                           
   
  Files changed: 2 Dockerfiles, 2 build scripts, 4 CI workflows, 5 doc files, CLAUDE.md                                                                                                                              
                                                                                                                                                                                                                   
  Unchanged (verified): devnet-entrypoint.sh, download-provers.sh, snarkOS feature flags (test_network and snarkos-node-metrics confirmed present in v4.6.0), minimum version validation guards (Leo >= v3.5.0,      
  snarkOS >= v4.5.3)
                                                                                                                                                                                                                     
  Open item                                                                                                                                                                                                        

  setup-leo-action SHA in the snapshot workflow and README is marked with TODO — needs updating after https://github.com/sealance-io/setup-leo-action/pull/13 merges.                                                
   
  Test plan                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  - shellcheck --severity=warning *.sh — passes                                                                                                                                                                      
  - hadolint leo.Dockerfile / hadolint aleo-devnet.Dockerfile — passes                                                                                                                                             
  - Local leo-lang build: ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --local-arch --no-push
  - Verify leo --version outputs v4.0.0                                                                                                                                                                              
  - Local aleo-devnet build: ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --local-arch --no-push
  - Devnet boots and REST API responds at /testnet/latest/height   
```                                                                                                                                                  
                                                                                                                                                                                                                   
  🤖 Generated with https://claude.com/claude-code                                                                                                                                                                   
