### PR TITLE
Migrate Aleo stack defaults to 4.7.0

### DIFF
--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -11,7 +11,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.0.2-v4.6.0'
+        default: 'v4.1.0-v4.7.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -29,9 +29,9 @@ on:
         default: false
         type: boolean
       consensus-version:
-        description: 'Target consensus version for devnet (default: 14)'
+        description: 'Target consensus version for devnet (default: 15)'
         required: false
-        default: 14
+        default: 15
         type: number
       required-programs:
         description: 'Comma-separated program IDs to verify. Empty = read from required-programs.txt'
@@ -53,7 +53,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.0.2-v4.6.0'
+        default: 'v4.1.0-v4.7.0'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -71,9 +71,9 @@ on:
         default: false
         type: boolean
       consensus-version:
-        description: 'Target consensus version for devnet (default: 14)'
+        description: 'Target consensus version for devnet (default: 15)'
         required: false
-        default: 14
+        default: 15
         type: number
       required-programs:
         description: 'Comma-separated program IDs to verify. Empty = read from required-programs.txt'
@@ -111,7 +111,7 @@ jobs:
         run: |
           # Extract Leo version from aleo-devnet-version (format: vX.Y.Z-vA.B.C)
           LEO_VERSION=$(echo "${INPUT_DEVNET_VERSION}" | cut -d'-' -f1 | sed 's/^v//')
-          echo "leo-version=${LEO_VERSION}" >> $GITHUB_OUTPUT
+          echo "leo-version=${LEO_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Parsed Leo version: ${LEO_VERSION}"
 
       - name: Validate aleo-devnet version
@@ -143,11 +143,11 @@ jobs:
 
       - name: Setup Leo CLI
         id: setup-leo
-        # TODO: update SHA after sealance-io/setup-leo-action PR #13 (Leo v4 support) merges
-        uses: sealance-io/setup-leo-action@126611b39ce92d063c50da6623f8a0b08bf294dd # v1.0.0
+        # PR #19 head: Support Leo 4.1.0 source tags. Replace with a release SHA once published.
+        uses: sealance-io/setup-leo-action@1a751b63289e0475d09058db0cbc18e88abc7048 # PR #19 head
         with:
           version: ${{ steps.parse-version.outputs.leo-version }}
-          rust-version: '1.94.1'
+          rust-version: '1.96.0'
           enable-cache: true
           cache-save: ${{ github.ref == 'refs/heads/main' && 'always' || 'never' }}
           run-audit: true
@@ -316,7 +316,7 @@ jobs:
           if [[ "${INPUT_SKIP_PUSH}" == "true" && -z "$PROGRAMS" ]]; then
             echo "::warning::No required programs resolved. Program verification will be skipped (skip-push mode)."
           fi
-          echo "list=${PROGRAMS}" >> $GITHUB_OUTPUT
+          echo "list=${PROGRAMS}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy programs
         working-directory: compliant-transfer-aleo-build
@@ -449,10 +449,12 @@ jobs:
           VERSION_TAG="${INPUT_DEVNET_VERSION}-${SHORT_SHA}"
 
           # Set outputs
-          echo "short-sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
-          echo "full-sha=${FULL_SHA}" >> $GITHUB_OUTPUT
-          echo "version-tag=${VERSION_TAG}" >> $GITHUB_OUTPUT
-          echo "image-name=${REGISTRY}/${REPO_OWNER}/${INPUT_IMAGE_NAME}" >> $GITHUB_OUTPUT
+          {
+            echo "short-sha=${SHORT_SHA}"
+            echo "full-sha=${FULL_SHA}"
+            echo "version-tag=${VERSION_TAG}"
+            echo "image-name=${REGISTRY}/${REPO_OWNER}/${INPUT_IMAGE_NAME}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push multi-platform image (version tag only)
         if: ${{ !inputs.skip-push }}
@@ -662,7 +664,7 @@ jobs:
           PULL_COMMAND: ${{ !inputs.skip-push && format('docker pull {0}:{1}', steps.meta.outputs.image-name, steps.meta.outputs.version-tag) || '' }}
         run: |
           set -euo pipefail
-          cat >> $GITHUB_STEP_SUMMARY << EOF
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
           # Build Summary
 
           ## 🚀 Custom Aleo Devnet Chain Image Built Successfully!

--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -143,8 +143,7 @@ jobs:
 
       - name: Setup Leo CLI
         id: setup-leo
-        # PR #19 head: Support Leo 4.1.0 source tags. Replace with a release SHA once published.
-        uses: sealance-io/setup-leo-action@1a751b63289e0475d09058db0cbc18e88abc7048 # PR #19 head
+        uses: sealance-io/setup-leo-action@f48a7d97c4a11affcd3d698a28d57e42dc4fc933 # v1.1.1
         with:
           version: ${{ steps.parse-version.outputs.leo-version }}
           rust-version: '1.96.0'

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -28,8 +28,13 @@ on:
         default: 'sealance-io'
         type: string
       project_version:
-        description: 'Project version to build (e.g., v4.0.2)'
+        description: 'Project version/image tag to build (e.g., v4.1.0 or v4.1.0-v4.7.0)'
         required: true
+        type: string
+      leo_source_tag:
+        description: 'Upstream Leo source tag for leo-lang builds (e.g., leo-lang-v4.1.0)'
+        required: false
+        default: ''
         type: string
       project_repo:
         description: 'Project repository URL'
@@ -48,7 +53,7 @@ on:
       snarkos_version:
         description: 'snarkOS version for aleo-devnet'
         required: false
-        default: 'v4.6.0'
+        default: 'v4.7.0'
         type: string
       rust_version:
         description: 'Rust version override (inferred from upstream if not set)'
@@ -58,6 +63,7 @@ on:
       leo_version:
         description: 'Leo version for aleo-devnet (if different from project_version)'
         required: false
+        default: 'v4.1.0'
         type: string
     secrets:
       registry_token:
@@ -75,6 +81,7 @@ jobs:
       project_repo: ${{ steps.set-params.outputs.project_repo }}
       project_repo_arg: ${{ steps.set-params.outputs.project_repo_arg }}
       project_version_arg: ${{ steps.set-params.outputs.project_version_arg }}
+      leo_source_tag: ${{ steps.set-params.outputs.leo_source_tag }}
       uses_target: ${{ steps.set-params.outputs.uses_target }}
       registry_image: ${{ steps.set-params.outputs.registry_image }}
       rust_version: ${{ steps.infer-rust.outputs.rust_version }}
@@ -86,19 +93,35 @@ jobs:
           INPUT_ORGANIZATION: ${{ inputs.organization }}
           INPUT_IMAGE_NAME: ${{ inputs.image_name }}
           INPUT_PROJECT_REPO: ${{ inputs.project_repo }}
+          INPUT_PROJECT_VERSION: ${{ inputs.project_version }}
+          INPUT_LEO_SOURCE_TAG: ${{ inputs.leo_source_tag }}
         run: |
           REGISTRY_IMAGE="${INPUT_REGISTRY}/${INPUT_ORGANIZATION}/${INPUT_IMAGE_NAME}"
-          echo "registry_image=${REGISTRY_IMAGE}" >> $GITHUB_OUTPUT
+          echo "registry_image=${REGISTRY_IMAGE}" >> "$GITHUB_OUTPUT"
 
           if [[ "${INPUT_IMAGE_NAME}" == "leo-lang" ]]; then
-            echo "project_repo_arg=LEO_REPO" >> $GITHUB_OUTPUT
-            echo "project_version_arg=LEO_VERSION" >> $GITHUB_OUTPUT
-            echo "project_repo=${INPUT_PROJECT_REPO:-https://github.com/ProvableHQ/leo}" >> $GITHUB_OUTPUT
-            echo "uses_target=true" >> $GITHUB_OUTPUT
+            LEO_SOURCE_TAG="${INPUT_LEO_SOURCE_TAG}"
+            if [[ -z "${LEO_SOURCE_TAG}" ]]; then
+              if [[ "${INPUT_PROJECT_VERSION}" == "v4.1.0" ]]; then
+                LEO_SOURCE_TAG="leo-lang-v4.1.0"
+              else
+                LEO_SOURCE_TAG="${INPUT_PROJECT_VERSION}"
+              fi
+            fi
+            {
+              echo "project_repo_arg=LEO_REPO"
+              echo "project_version_arg=LEO_VERSION"
+              echo "project_repo=${INPUT_PROJECT_REPO:-https://github.com/ProvableHQ/leo}"
+              echo "leo_source_tag=${LEO_SOURCE_TAG}"
+              echo "uses_target=true"
+            } >> "$GITHUB_OUTPUT"
           elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
-            echo "project_version_arg=LEO_VERSION" >> $GITHUB_OUTPUT
-            echo "project_repo=" >> $GITHUB_OUTPUT
-            echo "uses_target=false" >> $GITHUB_OUTPUT
+            {
+              echo "project_version_arg=LEO_VERSION"
+              echo "project_repo="
+              echo "leo_source_tag="
+              echo "uses_target=false"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "::error::Unknown image name: ${INPUT_IMAGE_NAME}"
             exit 1
@@ -110,19 +133,20 @@ jobs:
           INPUT_RUST_VERSION: ${{ inputs.rust_version }}
           INPUT_IMAGE_NAME: ${{ inputs.image_name }}
           PROJECT_REPO: ${{ steps.set-params.outputs.project_repo }}
+          LEO_SOURCE_TAG: ${{ steps.set-params.outputs.leo_source_tag }}
           INPUT_PROJECT_VERSION: ${{ inputs.project_version }}
           INPUT_SNARKOS_VERSION: ${{ inputs.snarkos_version }}
         run: |
           if [[ -n "${INPUT_RUST_VERSION}" ]]; then
-            echo "rust_version=${INPUT_RUST_VERSION}" >> $GITHUB_OUTPUT
+            echo "rust_version=${INPUT_RUST_VERSION}" >> "$GITHUB_OUTPUT"
             echo "Using explicitly provided Rust version: ${INPUT_RUST_VERSION}"
           else
             if [[ "${INPUT_IMAGE_NAME}" == "leo-lang" ]]; then
               REPO_PATH=$(echo "${PROJECT_REPO}" | sed -e 's|https://github.com/||' -e 's|\.git$||')
-              TAG="${INPUT_PROJECT_VERSION}"
+              TAG="${LEO_SOURCE_TAG}"
             elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
               REPO_PATH="ProvableHQ/snarkOS"
-              TAG="${INPUT_SNARKOS_VERSION:-v4.6.0}"
+              TAG="${INPUT_SNARKOS_VERSION:-v4.7.0}"
             fi
 
             CHANNEL=$(curl -sSf --max-time 10 \
@@ -130,12 +154,21 @@ jobs:
               | sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
               | tr -d '[:space:]') || true
 
+            if [[ "$CHANNEL" =~ ^[0-9]+\.[0-9]+$ ]]; then
+              CHANNEL="${CHANNEL}.0"
+            fi
+
             if [[ -n "$CHANNEL" && "$CHANNEL" != *nightly* ]]; then
-              echo "rust_version=${CHANNEL}" >> $GITHUB_OUTPUT
+              echo "rust_version=${CHANNEL}" >> "$GITHUB_OUTPUT"
               echo "Inferred Rust version: ${CHANNEL}"
             else
-              echo "rust_version=1.94.1" >> $GITHUB_OUTPUT
-              echo "Could not infer Rust version, using default: 1.94.1"
+              if [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
+                echo "rust_version=1.88.0" >> "$GITHUB_OUTPUT"
+                echo "Could not infer Rust version, using default: 1.88.0"
+              else
+                echo "rust_version=1.96.0" >> "$GITHUB_OUTPUT"
+                echo "Could not infer Rust version, using default: 1.96.0"
+              fi
             fi
           fi
 
@@ -195,6 +228,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.determine-params.outputs.project_version_arg }}=${{ inputs.project_version }}
+            LEO_SOURCE_TAG=${{ needs.determine-params.outputs.leo_source_tag }}
             ${{ needs.determine-params.outputs.project_repo_arg }}=${{ needs.determine-params.outputs.project_repo }}
             RUST_VERSION=${{ needs.determine-params.outputs.rust_version }}
             NODE_VERSION=${{ inputs.node_version || '24' }}
@@ -213,8 +247,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            LEO_VERSION=${{ inputs.leo_version || 'v4.0.2' }}
-            SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.6.0' }}
+            LEO_VERSION=${{ inputs.leo_version || 'v4.1.0' }}
+            SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.7.0' }}
             RUST_VERSION=${{ needs.determine-params.outputs.rust_version }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true,name=${{ needs.determine-params.outputs.registry_image }}
           cache-from: type=registry,ref=${{ needs.determine-params.outputs.registry_image }}:cache-${{ matrix.platform_pair }}
@@ -278,6 +312,7 @@ jobs:
         env:
           REGISTRY_IMAGE: ${{ needs.determine-params.outputs.registry_image }}
         run: |
+          # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${REGISTRY_IMAGE}@sha256:%s " *)

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -9,13 +9,13 @@ on:
     # Allow manual trigger for testing
     inputs:
       minimum_leo_version:
-        description: 'Minimum Leo version to build (defaults to v4.0.2)'
+        description: 'Minimum Leo image version to build (defaults to v4.1.0)'
         required: false
-        default: 'v4.0.2'
+        default: 'v4.1.0'
       minimum_snarkos_version:
-        description: 'Minimum snarkOS version to build (defaults to v4.6.0)'
+        description: 'Minimum snarkOS version to build (defaults to v4.7.0)'
         required: false
-        default: 'v4.6.0'
+        default: 'v4.7.0'
 
 permissions: {}
 
@@ -36,15 +36,17 @@ jobs:
       - name: Set up variables
         id: vars
         env:
-          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v4.0.2' }}
-          INPUT_MIN_SNARKOS: ${{ inputs.minimum_snarkos_version || 'v4.6.0' }}
+          INPUT_MIN_LEO: ${{ inputs.minimum_leo_version || 'v4.1.0' }}
+          INPUT_MIN_SNARKOS: ${{ inputs.minimum_snarkos_version || 'v4.7.0' }}
         run: |
-          echo "leo_repo=ProvableHQ/leo" >> $GITHUB_OUTPUT
-          echo "snarkos_repo=ProvableHQ/snarkOS" >> $GITHUB_OUTPUT
-          echo "registry=ghcr.io" >> $GITHUB_OUTPUT
-          echo "organization=sealance-io" >> $GITHUB_OUTPUT
-          echo "min_leo_version=${INPUT_MIN_LEO}" >> $GITHUB_OUTPUT
-          echo "min_snarkos_version=${INPUT_MIN_SNARKOS}" >> $GITHUB_OUTPUT
+          {
+            echo "leo_repo=ProvableHQ/leo"
+            echo "snarkos_repo=ProvableHQ/snarkOS"
+            echo "registry=ghcr.io"
+            echo "organization=sealance-io"
+            echo "min_leo_version=${INPUT_MIN_LEO}"
+            echo "min_snarkos_version=${INPUT_MIN_SNARKOS}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup for Act detection
         id: detect_act
@@ -52,9 +54,9 @@ jobs:
           # Determine if we're running under Act
           if [ -n "$ACT" ]; then
             echo "Running in Act testing mode"
-            echo "testing_mode=true" >> $GITHUB_OUTPUT
+            echo "testing_mode=true" >> "$GITHUB_OUTPUT"
           else
-            echo "testing_mode=false" >> $GITHUB_OUTPUT
+            echo "testing_mode=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Authenticate with Registry
@@ -74,8 +76,11 @@ jobs:
           MIN_VERSION="${MIN_LEO_VERSION}"
           MIN_VERSION_NORM=${MIN_VERSION#v}
 
-          # Get the latest releases from GitHub
-          LATEST_TAGS=$(gh api "repos/${LEO_REPO}/releases" --jq '.[].tag_name' | sort -V)
+          # Get Leo CLI source releases only. The repo also publishes crate-specific
+          # tags such as leo-abi-vX.Y.Z that must not become image tags.
+          LATEST_SOURCE_TAGS=$(gh api "repos/${LEO_REPO}/releases" --jq '.[].tag_name' \
+            | grep -E '^leo-lang-v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9.]+)?$' \
+            | sort -V)
 
           # Get current tags from the container registry
           readarray -t EXISTING_TAGS < <(
@@ -86,39 +91,57 @@ jobs:
             | jq -r '.[].metadata.container.tags[]' 2>/dev/null || echo ""
           )
 
-          NEW_TAGS=""
-          QUALIFIED_TAGS=()
+          NEW_IMAGE_TAGS=""
+          NEW_SOURCE_TAGS=""
+          QUALIFIED_IMAGE_TAGS=()
 
-          for TAG in $LATEST_TAGS; do
-            TAG_NORM=${TAG#v}
+          for SOURCE_TAG in $LATEST_SOURCE_TAGS; do
+            IMAGE_TAG="${SOURCE_TAG#leo-lang-}"
+            TAG_NORM=${IMAGE_TAG#v}
 
             # Skip tags with versions lower than minimum
-            if [[ "$(printf '%s\n' "$MIN_VERSION_NORM" "$TAG_NORM" | sort -V | head -n1)" != "$TAG_NORM" ]]; then
-              QUALIFIED_TAGS+=("$TAG")
+            if [[ "$(printf '%s\n' "$MIN_VERSION_NORM" "$TAG_NORM" | sort -V | head -n1)" == "$MIN_VERSION_NORM" ]]; then
+              QUALIFIED_IMAGE_TAGS+=("$IMAGE_TAG")
 
-              if [[ ! " ${EXISTING_TAGS[*]} " =~ " ${TAG} " ]]; then
-                if [[ -n "$NEW_TAGS" ]]; then
-                  NEW_TAGS="$NEW_TAGS,$TAG"
-                else
-                  NEW_TAGS="$TAG"
+              TAG_EXISTS=false
+              for EXISTING_TAG in "${EXISTING_TAGS[@]}"; do
+                if [[ "${EXISTING_TAG}" == "${IMAGE_TAG}" ]]; then
+                  TAG_EXISTS=true
+                  break
                 fi
-                echo "Found new Leo tag: $TAG (meets minimum version $MIN_VERSION)"
+              done
+
+              if [[ "${TAG_EXISTS}" != "true" ]]; then
+                if [[ -n "$NEW_IMAGE_TAGS" ]]; then
+                  NEW_IMAGE_TAGS="$NEW_IMAGE_TAGS,$IMAGE_TAG"
+                  NEW_SOURCE_TAGS="$NEW_SOURCE_TAGS,$SOURCE_TAG"
+                else
+                  NEW_IMAGE_TAGS="$IMAGE_TAG"
+                  NEW_SOURCE_TAGS="$SOURCE_TAG"
+                fi
+                echo "Found new Leo source tag: $SOURCE_TAG -> image tag $IMAGE_TAG (meets minimum version $MIN_VERSION)"
               fi
             else
-              echo "Skipping Leo tag: $TAG (below minimum version $MIN_VERSION)"
+              echo "Skipping Leo source tag: $SOURCE_TAG (below minimum version $MIN_VERSION)"
             fi
           done
 
           # Determine the latest version from all qualified tags
           LATEST_VERSION=""
-          if [ ${#QUALIFIED_TAGS[@]} -gt 0 ]; then
-            SORTED_TAGS=$(printf '%s\n' "${QUALIFIED_TAGS[@]}" | sort -rV)
+          LATEST_SOURCE_TAG=""
+          if [ ${#QUALIFIED_IMAGE_TAGS[@]} -gt 0 ]; then
+            SORTED_TAGS=$(printf '%s\n' "${QUALIFIED_IMAGE_TAGS[@]}" | sort -rV)
             LATEST_VERSION=$(echo "$SORTED_TAGS" | head -n1)
-            echo "Latest Leo version is: $LATEST_VERSION"
+            LATEST_SOURCE_TAG="leo-lang-${LATEST_VERSION}"
+            echo "Latest Leo image version is: $LATEST_VERSION (source tag: $LATEST_SOURCE_TAG)"
           fi
 
-          echo "new_tags=${NEW_TAGS}" >> $GITHUB_OUTPUT
-          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          {
+            echo "new_tags=${NEW_IMAGE_TAGS}"
+            echo "new_source_tags=${NEW_SOURCE_TAGS}"
+            echo "latest_version=${LATEST_VERSION}"
+            echo "latest_source_tag=${LATEST_SOURCE_TAG}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check for new snarkOS releases
         id: check-snarkos
@@ -131,8 +154,10 @@ jobs:
           MIN_VERSION="${MIN_SNARKOS_VERSION}"
           MIN_VERSION_NORM=${MIN_VERSION#v}
 
-          # Get the latest releases from GitHub
-          LATEST_TAGS=$(gh api "repos/${SNARKOS_REPO}/releases" --jq '.[].tag_name' | sort -V)
+          # Get stable snarkOS releases only.
+          LATEST_TAGS=$(gh api "repos/${SNARKOS_REPO}/releases" --jq '.[].tag_name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9.]+)?$' \
+            | sort -V)
 
           # Get current aleo-devnet tags from the container registry
           # These are in format vX.Y.Z-vA.B.C (leo-snarkos)
@@ -151,7 +176,7 @@ jobs:
             TAG_NORM=${TAG#v}
 
             # Skip tags with versions lower than minimum
-            if [[ "$(printf '%s\n' "$MIN_VERSION_NORM" "$TAG_NORM" | sort -V | head -n1)" != "$TAG_NORM" ]]; then
+            if [[ "$(printf '%s\n' "$MIN_VERSION_NORM" "$TAG_NORM" | sort -V | head -n1)" == "$MIN_VERSION_NORM" ]]; then
               QUALIFIED_TAGS+=("$TAG")
               echo "Qualified snarkOS tag: $TAG (meets minimum version $MIN_VERSION)"
 
@@ -177,25 +202,30 @@ jobs:
           fi
 
           # Export existing devnet tags for use in trigger step
-          echo "existing_devnet_tags=${EXISTING_DEVNET_TAGS[*]}" >> $GITHUB_OUTPUT
-          echo "qualified_tags=${NEW_TAGS}" >> $GITHUB_OUTPUT
-          echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          {
+            echo "existing_devnet_tags=${EXISTING_DEVNET_TAGS[*]}"
+            echo "qualified_tags=${NEW_TAGS}"
+            echo "latest_version=${LATEST_VERSION}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Trigger Leo builds (GitHub)
         if: steps.check-leo.outputs.new_tags != '' && steps.detect_act.outputs.testing_mode != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           LEO_NEW_TAGS: ${{ steps.check-leo.outputs.new_tags }}
+          LEO_NEW_SOURCE_TAGS: ${{ steps.check-leo.outputs.new_source_tags }}
           LEO_LATEST_VERSION: ${{ steps.check-leo.outputs.latest_version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const tags = process.env.LEO_NEW_TAGS.split(',');
+            const tags = process.env.LEO_NEW_TAGS.split(',').filter(Boolean);
+            const sourceTags = process.env.LEO_NEW_SOURCE_TAGS.split(',').filter(Boolean);
             const latestVersion = process.env.LEO_LATEST_VERSION;
 
-            for (const tag of tags) {
+            for (const [index, tag] of tags.entries()) {
+              const sourceTag = sourceTags[index] || '';
               const isLatest = tag === latestVersion;
-              console.log(`Triggering build for Leo tag: ${tag} (Latest: ${isLatest})`);
+              console.log(`Triggering build for Leo image tag: ${tag} from source tag: ${sourceTag} (Latest: ${isLatest})`);
 
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
@@ -205,6 +235,7 @@ jobs:
                 inputs: {
                   image_name: 'leo-lang',
                   leo_version: tag,
+                  leo_source_tag: sourceTag,
                   tag_latest: isLatest.toString()
                 }
               });
@@ -215,7 +246,9 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           LEO_NEW_TAGS: ${{ steps.check-leo.outputs.new_tags }}
+          LEO_NEW_SOURCE_TAGS: ${{ steps.check-leo.outputs.new_source_tags }}
           LEO_LATEST_VERSION: ${{ steps.check-leo.outputs.latest_version }}
+          LEO_LATEST_SOURCE_TAG: ${{ steps.check-leo.outputs.latest_source_tag }}
           SNARKOS_QUALIFIED_TAGS: ${{ steps.check-snarkos.outputs.qualified_tags }}
           SNARKOS_LATEST_VERSION: ${{ steps.check-snarkos.outputs.latest_version }}
           EXISTING_DEVNET_TAGS: ${{ steps.check-snarkos.outputs.existing_devnet_tags }}
@@ -223,7 +256,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const newLeoTags = process.env.LEO_NEW_TAGS.split(',').filter(t => t);
+            const newLeoSourceTags = process.env.LEO_NEW_SOURCE_TAGS.split(',').filter(t => t);
             const latestLeoVersion = process.env.LEO_LATEST_VERSION;
+            const latestLeoSourceTag = process.env.LEO_LATEST_SOURCE_TAG;
             const qualifiedSnarkOsTags = process.env.SNARKOS_QUALIFIED_TAGS.split(',').filter(t => t);
             const latestSnarkOsVersion = process.env.SNARKOS_LATEST_VERSION;
             const existingDevnetTags = process.env.EXISTING_DEVNET_TAGS.split(' ').filter(t => t);
@@ -231,14 +266,16 @@ jobs:
             const buildsToTrigger = [];
 
             // For new Leo versions, build with latest snarkOS
-            for (const leoTag of newLeoTags) {
+            for (const [index, leoTag] of newLeoTags.entries()) {
               if (latestSnarkOsVersion) {
+                const leoSourceTag = newLeoSourceTags[index] || '';
                 const combinedTag = `${leoTag}-${latestSnarkOsVersion}`;
                 if (!existingDevnetTags.includes(combinedTag)) {
                   buildsToTrigger.push({
                     leoVersion: leoTag,
+                    leoSourceTag,
                     snarkOsVersion: latestSnarkOsVersion,
-                    isLatest: leoTag === latestLeoVersion && latestSnarkOsVersion === latestSnarkOsVersion
+                    isLatest: leoTag === latestLeoVersion
                   });
                 }
               }
@@ -257,8 +294,9 @@ jobs:
                   if (!alreadyQueued) {
                     buildsToTrigger.push({
                       leoVersion: latestLeoVersion,
+                      leoSourceTag: latestLeoSourceTag,
                       snarkOsVersion: snarkOsTag,
-                      isLatest: latestLeoVersion === latestLeoVersion && snarkOsTag === latestSnarkOsVersion
+                      isLatest: snarkOsTag === latestSnarkOsVersion
                     });
                   }
                 }
@@ -267,7 +305,7 @@ jobs:
 
             // Trigger builds
             for (const build of buildsToTrigger) {
-              console.log(`Triggering aleo-devnet build: Leo ${build.leoVersion} + snarkOS ${build.snarkOsVersion} (Latest: ${build.isLatest})`);
+              console.log(`Triggering aleo-devnet build: Leo ${build.leoVersion} (${build.leoSourceTag}) + snarkOS ${build.snarkOsVersion} (Latest: ${build.isLatest})`);
 
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
@@ -277,6 +315,7 @@ jobs:
                 inputs: {
                   image_name: 'aleo-devnet',
                   leo_version: build.leoVersion,
+                  leo_source_tag: build.leoSourceTag,
                   snarkos_version: build.snarkOsVersion,
                   tag_latest: build.isLatest.toString()
                 }
@@ -292,7 +331,9 @@ jobs:
         if: steps.detect_act.outputs.testing_mode == 'true'
         env:
           LEO_NEW_TAGS: ${{ steps.check-leo.outputs.new_tags }}
+          LEO_NEW_SOURCE_TAGS: ${{ steps.check-leo.outputs.new_source_tags }}
           LEO_LATEST_VERSION: ${{ steps.check-leo.outputs.latest_version }}
+          LEO_LATEST_SOURCE_TAG: ${{ steps.check-leo.outputs.latest_source_tag }}
           SNARKOS_LATEST_VERSION: ${{ steps.check-snarkos.outputs.latest_version }}
           SNARKOS_QUALIFIED_TAGS: ${{ steps.check-snarkos.outputs.qualified_tags }}
         run: |
@@ -301,12 +342,17 @@ jobs:
           # Process Leo triggers
           if [ -n "${LEO_NEW_TAGS}" ]; then
             echo "Leo tags to build: ${LEO_NEW_TAGS}"
+            echo "Leo source tags to build: ${LEO_NEW_SOURCE_TAGS}"
             echo "Leo latest version: ${LEO_LATEST_VERSION}"
+            echo "Leo latest source tag: ${LEO_LATEST_SOURCE_TAG}"
 
             IFS=',' read -ra TAGS <<< "${LEO_NEW_TAGS}"
+            IFS=',' read -ra SOURCE_TAGS <<< "${LEO_NEW_SOURCE_TAGS}"
             LATEST="${LEO_LATEST_VERSION}"
 
-            for TAG in "${TAGS[@]}"; do
+            for INDEX in "${!TAGS[@]}"; do
+              TAG="${TAGS[$INDEX]}"
+              SOURCE_TAG="${SOURCE_TAGS[$INDEX]:-}"
               IS_LATEST="false"
               if [ "$TAG" = "$LATEST" ]; then
                 IS_LATEST="true"
@@ -315,6 +361,7 @@ jobs:
               echo "Would trigger: manual-build.yml for Leo with:"
               echo "  - image_name: leo-lang"
               echo "  - leo_version: $TAG"
+              echo "  - leo_source_tag: $SOURCE_TAG"
               echo "  - tag_latest: $IS_LATEST"
               echo ""
             done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: Run ShellCheck
-        run: shellcheck --severity=warning *.sh
+        run: shellcheck --severity=warning ./*.sh
 
   # ============================================================================
   # Lint status aggregation for branch protection

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -11,14 +11,19 @@ on:
           - leo-lang
           - aleo-devnet
       leo_version:
-        description: 'Leo version (e.g., v4.0.2)'
+        description: 'Leo image version (e.g., v4.1.0)'
         required: true
         type: string
-        default: 'v4.0.2'
+        default: 'v4.1.0'
+      leo_source_tag:
+        description: 'Leo upstream source tag (leo-lang only; blank derives default)'
+        required: false
+        type: string
+        default: ''
       snarkos_version:
         description: 'snarkOS version (aleo-devnet only)'
         type: string
-        default: 'v4.6.0'
+        default: 'v4.7.0'
         required: false
       tag_latest:
         description: 'Tag as latest'
@@ -35,6 +40,7 @@ jobs:
     outputs:
       dockerfile: ${{ steps.derive.outputs.dockerfile }}
       project_version: ${{ steps.derive.outputs.project_version }}
+      leo_source_tag: ${{ steps.derive.outputs.leo_source_tag }}
       snarkos_version: ${{ steps.derive.outputs.snarkos_version }}
     steps:
       - name: Derive parameters from image name
@@ -42,23 +48,38 @@ jobs:
         env:
           INPUT_IMAGE_NAME: ${{ inputs.image_name }}
           INPUT_LEO_VERSION: ${{ inputs.leo_version }}
+          INPUT_LEO_SOURCE_TAG: ${{ inputs.leo_source_tag }}
           INPUT_SNARKOS_VERSION: ${{ inputs.snarkos_version }}
         run: |
           LEO_VERSION="${INPUT_LEO_VERSION}"
+          LEO_SOURCE_TAG="${INPUT_LEO_SOURCE_TAG}"
           SNARKOS_VERSION="${INPUT_SNARKOS_VERSION}"
-          SNARKOS_VERSION="${SNARKOS_VERSION:-v4.6.0}"
+          SNARKOS_VERSION="${SNARKOS_VERSION:-v4.7.0}"
 
           if [[ "${INPUT_IMAGE_NAME}" == "leo-lang" ]]; then
-            echo "dockerfile=leo.Dockerfile" >> $GITHUB_OUTPUT
-            # For leo-lang, project_version is just the Leo version
-            echo "project_version=${LEO_VERSION}" >> $GITHUB_OUTPUT
+            if [[ -z "${LEO_SOURCE_TAG}" ]]; then
+              if [[ "${LEO_VERSION}" == "v4.1.0" ]]; then
+                LEO_SOURCE_TAG="leo-lang-v4.1.0"
+              else
+                LEO_SOURCE_TAG="${LEO_VERSION}"
+              fi
+            fi
+            {
+              echo "dockerfile=leo.Dockerfile"
+              # For leo-lang, project_version is just the Leo version
+              echo "project_version=${LEO_VERSION}"
+              echo "leo_source_tag=${LEO_SOURCE_TAG}"
+            } >> "$GITHUB_OUTPUT"
           elif [[ "${INPUT_IMAGE_NAME}" == "aleo-devnet" ]]; then
-            echo "dockerfile=aleo-devnet.Dockerfile" >> $GITHUB_OUTPUT
-            # For aleo-devnet, project_version is combined: v4.0.2-v4.6.0
-            echo "project_version=${LEO_VERSION}-${SNARKOS_VERSION}" >> $GITHUB_OUTPUT
+            {
+              echo "dockerfile=aleo-devnet.Dockerfile"
+              # For aleo-devnet, project_version is combined: v4.1.0-v4.7.0
+              echo "project_version=${LEO_VERSION}-${SNARKOS_VERSION}"
+              echo "leo_source_tag="
+            } >> "$GITHUB_OUTPUT"
           fi
 
-          echo "snarkos_version=${SNARKOS_VERSION}" >> $GITHUB_OUTPUT
+          echo "snarkos_version=${SNARKOS_VERSION}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: derive-params
@@ -70,6 +91,7 @@ jobs:
       image_name: ${{ inputs.image_name }}
       dockerfile: ${{ needs.derive-params.outputs.dockerfile }}
       project_version: ${{ needs.derive-params.outputs.project_version }}
+      leo_source_tag: ${{ needs.derive-params.outputs.leo_source_tag }}
       leo_version: ${{ inputs.leo_version }}
       snarkos_version: ${{ needs.derive-params.outputs.snarkos_version }}
       tag_latest: ${{ inputs.tag_latest }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,14 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 
 ```bash
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
-./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0 --consensus-version 14
+./build-publish-deployment-snapshot.sh --commit main --version v4.1.0-v4.7.0 --consensus-version 15
 ```
 
 ### Run Containers
 
 ```bash
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2 leo --help
-docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.1.0 leo --help
+docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0
 curl http://localhost:3030/testnet/latest/height
 ```
 
@@ -69,9 +69,11 @@ All scripts use `set -euo pipefail` with `IFS=$'\n\t'` and are validated with [s
 
 - **Build order**: `leo-lang` must be built/published before `aleo-devnet` (`COPY --from` dependency)
 - **Version format**: Devnet tags are strictly `vX.Y.Z-vA.B.C` (Leo-snarkOS)
+- **Leo source tag split**: Public image tags stay normalized (`LEO_VERSION=v4.1.0`), while Leo `v4.1.0` clones from upstream `LEO_SOURCE_TAG=leo-lang-v4.1.0`
 - **Minimum versions**: Leo >= v3.5.0, snarkOS >= v4.5.3 (required for non-root user and `/aleo/data` layout)
 - **Hadolint ignores**: `.hadolint.yaml` ignores DL3008 and DL3059 intentionally — do not remove
-- **Rust version**: `RUST_VERSION` is auto-inferred from upstream `rust-toolchain.toml` — only override explicitly
+- **Rust version**: `RUST_VERSION` is auto-inferred from upstream `rust-toolchain.toml`; keep it per component (Leo v4.1.0 uses 1.96.0, snarkOS v4.7.0 declares 1.88 and Docker base tags normalize to 1.88.0)
+- **Snapshot consensus**: Deployment snapshots default to consensus version 15 and generated heights `0..14`
 - **Fail-closed policy**: Publish flows require a non-empty program list from `required-programs.txt`
 - **SHA-pinned actions**: All workflow `uses:` reference full commit SHAs, not mutable tags — include version as trailing comment
 - **`persist-credentials: false`**: Required on all `actions/checkout` steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 # Build aleo-devnet locally (requires leo-lang image)
 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --local-arch --no-push
 
-# Build deployment snapshot
+# Build deployment snapshot (default base v4.1.0-v4.7.0, consensus 15)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
 
 # Lint (required before completing any task)
@@ -62,10 +62,14 @@ Both Dockerfiles use [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) 
 ### Rust Toolchain Version Handling
 
 Two layers work together:
-1. **Build-time inference**: `infer_rust_version()` in the build script (and CI) fetches upstream `rust-toolchain.toml` to set the Docker base image tag. Falls back to `1.94.1`.
+1. **Build-time inference**: `infer_rust_version()` in the build script (and CI) fetches upstream `rust-toolchain.toml` to set the Docker base image tag. Leo inference uses `LEO_SOURCE_TAG`; snarkOS inference uses `SNARKOS_VERSION`.
 2. **Dockerfile-level**: The actual compiler is determined by `rust-toolchain.toml` copied from the cloned repo. The base image just needs `rustup`.
 
-`RUST_VERSION` is auto-inferred — only override explicitly.
+`RUST_VERSION` is auto-inferred — only override explicitly. Keep Rust per component: Leo `v4.1.0` uses Rust `1.96.0`; snarkOS `v4.7.0` declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
+
+### Leo Source Tags vs Image Tags
+
+Public Leo image tags are normalized (`LEO_VERSION=v4.1.0`), but upstream source uses `LEO_SOURCE_TAG=leo-lang-v4.1.0`. `LEO_VERSION` controls published image tags; `LEO_SOURCE_TAG` controls the Leo git clone and Rust inference. If unset, only the default `v4.1.0` derives `leo-lang-v4.1.0`; other versions fall back to `LEO_VERSION`.
 
 ### Devnet Entrypoint Three-Way Branching
 
@@ -81,6 +85,7 @@ Two layers work together:
 - **Hadolint ignores**: `.hadolint.yaml` ignores DL3008 and DL3059 intentionally — do not remove
 - **Fail-closed policy**: Publish flows require a non-empty program list from `required-programs.txt`
 - **snarkOS features**: Build uses `default,snarkos-node-metrics,test_network` — `test_network` is required for devnet
+- **Snapshot consensus**: Deployment snapshots default to consensus version 15 and generated heights `0..14`
 
 ### CI Hardening (maintain when editing workflows)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository provides multi-architecture (AMD64/ARM64) Docker images for Aleo
 
 Pre-built images are available on GitHub Container Registry:
 
-- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.0.2`
-- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0`
+- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.1.0`
+- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0`
 
 ### Custom Deployment Snapshots
 - **With deployed programs**: `ghcr.io/sealance-io/aleo-devnet-custom:latest`
@@ -22,14 +22,14 @@ You can also use the `latest` tag to always get the most recent version.
 ### Image Contents
 
 #### Leo Lang (`leo-lang`)
-- Leo CLI v4.0.2
+- Leo CLI v4.1.0
 - Node.js v24
 - Debian trixie (slim)
 - Essential SSL libraries
 
 #### Aleo Devnet Image (`aleo-devnet`)
-- Leo CLI v4.0.2
-- snarkOS v4.6.0
+- Leo CLI v4.1.0
+- snarkOS v4.7.0
 - Pre-downloaded mainnet prover parameters (~2GB)
 - Debian trixie (slim)
 - Essential runtime libraries
@@ -43,16 +43,16 @@ For development, deployment, and running Leo applications:
 
 ```bash
 # Run the Leo CLI directly
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2 leo --help
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.1.0 leo --help
 
 # Check installed versions
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.0.2
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.1.0
 
 # Mount your project directory and work with Leo
-docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.2 leo build
+docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.1.0 leo build
 
 # Start a shell in the container
-docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.0.2 /bin/bash
+docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.1.0 /bin/bash
 ```
 
 ### Aleo Devnet Image
@@ -63,25 +63,25 @@ For running a local Aleo development network with Leo and snarkOS:
 # Run a minimal devnet (4 validators + 1 client)
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0
+  ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0
 
 # Run with custom devnet parameters
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0 \
   devnet --storage /aleo/data --clear-storage --yes \
   --verbosity 4 --num-validators 4 --num-clients 2
 
 # Run snarkOS directly instead of Leo devnet command
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   --entrypoint ./snarkos \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0 \
   start --client --nodisplay --node 0.0.0.0:4130 \
   --network 1 --dev 0 --rest 0.0.0.0:3030
 
 # Access Leo CLI for development
 docker run -it --rm -v $(pwd):/app -w /app \
-  ghcr.io/sealance-io/aleo-devnet:v4.0.2-v4.6.0 \
+  ghcr.io/sealance-io/aleo-devnet:v4.1.0-v4.7.0 \
   new my_project
 ```
 #### GitHub Actions Example
@@ -104,10 +104,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Leo CLI
-        # TODO: update SHA after sealance-io/setup-leo-action PR #13 (Leo v4 support) merges
-        uses: sealance-io/setup-leo-action@126611b39ce92d063c50da6623f8a0b08bf294dd # v1.0.0
+        # PR #19 head; replace with a release SHA once published.
+        uses: sealance-io/setup-leo-action@1a751b63289e0475d09058db0cbc18e88abc7048 # PR #19 head
         with:
-          version: '4.0.2'
+          version: '4.1.0'
+          rust-version: '1.96.0'
 
       - name: Build Leo project
         run: leo build
@@ -117,6 +118,15 @@ jobs:
 ```
 
 See [setup-leo-action](https://github.com/sealance-io/setup-leo-action) for more options.
+
+### Leo Image Tags vs Source Tags
+
+Published image tags stay normalized as `v4.1.0`, but the upstream Leo source tag for this release is `leo-lang-v4.1.0`. Build scripts and workflows keep these separate:
+
+- `LEO_VERSION=v4.1.0` controls the public image tag.
+- `LEO_SOURCE_TAG=leo-lang-v4.1.0` controls the upstream git clone and Rust toolchain inference.
+
+When `LEO_SOURCE_TAG` is empty, the default `LEO_VERSION=v4.1.0` derives `leo-lang-v4.1.0`; other Leo versions fall back to using `LEO_VERSION` as the source tag for compatibility.
 
 ## 🔄 CI/CD Automation
 
@@ -178,10 +188,10 @@ The repository includes a script to create custom Aleo devnet images with pre-de
 ./build-publish-deployment-snapshot.sh --commit abc1234 --skip-push
 
 # Build with custom base image version
-./build-publish-deployment-snapshot.sh --version v4.0.2-v4.6.0 --skip-push
+./build-publish-deployment-snapshot.sh --version v4.1.0-v4.7.0 --skip-push
 
 # Build and push to registry (requires authentication)
-./build-publish-deployment-snapshot.sh --commit main --version v4.0.2-v4.6.0
+./build-publish-deployment-snapshot.sh --commit main --version v4.1.0-v4.7.0
 
 # Override required programs for verification (default: from required-programs.txt)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push --required-programs "merkle_tree.aleo,custom.aleo"
@@ -193,6 +203,7 @@ The repository includes a script to create custom Aleo devnet images with pre-de
 This script:
 - Clones the compliant-transfer-aleo repository
 - Starts a local Aleo devnet container (volume mounted at `/aleo/data` only)
+- Targets consensus version 15 by default, generating `CONSENSUS_VERSION_HEIGHTS=0,1,...,14`
 - Deploys programs to the devnet
 - Verifies required programs exist via REST API before stopping the container
 - Captures only blockchain state (not runtime files) from the container
@@ -219,19 +230,20 @@ The `--variant` flag allows you to add a suffix to version tags (not `latest`), 
 ```bash
 # Build Leo with Node.js 24
 NODE_VERSION=24 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --variant node24
-# Produces: leo-lang:v4.0.2-node24, leo-lang:latest
+# Produces: leo-lang:v4.1.0-node24, leo-lang:latest
 
 # Build with custom Rust version
-RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --variant rust189
-# Produces: aleo-devnet:v4.0.2-v4.6.0-rust189, aleo-devnet:latest
+RUST_VERSION=1.88.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --variant rust188
+# Produces: aleo-devnet:v4.1.0-v4.7.0-rust188, aleo-devnet:latest
 ```
 
 ### Environment Variables
 
 | Variable | Applies to | Description |
 |---|---|---|
-| `LEO_VERSION` | both | Leo release tag (default: `v4.0.2`) |
-| `SNARKOS_VERSION` | aleo-devnet | snarkOS release tag (default: `v4.6.0`) |
+| `LEO_VERSION` | both | Normalized Leo image/version tag (default: `v4.1.0`) |
+| `LEO_SOURCE_TAG` | leo-lang | Upstream Leo source tag used for clone/toolchain inference (default: `leo-lang-v4.1.0` when `LEO_VERSION=v4.1.0`) |
+| `SNARKOS_VERSION` | aleo-devnet | snarkOS release tag (default: `v4.7.0`) |
 | `LEO_REPO` | both | Leo Git URL (default: ProvableHQ/leo) |
 | `RUST_VERSION` | both | Rust base image tag (auto-inferred from upstream `rust-toolchain.toml`) |
 | `NODE_VERSION` | leo-lang | Node.js major version (default: `24`) |
@@ -240,7 +252,7 @@ RUST_VERSION=1.89.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.0.2" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
+LEO_VERSION="v4.1.0" LEO_SOURCE_TAG="leo-lang-v4.1.0" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 ```
 
@@ -271,7 +283,7 @@ echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 Add the appropriate user permissions:
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.0.2 leo build
+docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.1.0 leo build
 ```
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Leo CLI
-        # PR #19 head; replace with a release SHA once published.
-        uses: sealance-io/setup-leo-action@1a751b63289e0475d09058db0cbc18e88abc7048 # PR #19 head
+        uses: sealance-io/setup-leo-action@f48a7d97c4a11affcd3d698a28d57e42dc4fc933 # v1.1.1
         with:
           version: '4.1.0'
           rust-version: '1.96.0'

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -3,8 +3,8 @@
 # Run: docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data aleo-devnet
 
 # Build arguments
-ARG LEO_VERSION=v4.0.2
-ARG SNARKOS_VERSION=v4.6.0
+ARG LEO_VERSION=v4.1.0
+ARG SNARKOS_VERSION=v4.7.0
 # Used to pin Rust base images.
 ARG RUST_VERSION=1.88.0
 

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -21,7 +21,7 @@ FROM rust:${RUST_VERSION}-trixie AS snarkos-planner
 ARG SNARKOS_VERSION
 
 # Install cargo-chef and git
-RUN cargo install cargo-chef \
+RUN cargo install cargo-chef --locked \
     && apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
@@ -43,7 +43,7 @@ FROM rust:${RUST_VERSION}-trixie AS snarkos-builder
 ARG SNARKOS_VERSION
 
 # Install cargo-chef and build dependencies
-RUN cargo install cargo-chef \
+RUN cargo install cargo-chef --locked \
     && apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     clang \

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -39,15 +39,15 @@ usage() {
     echo ""
     echo "Options:"
     echo "  -c, --commit <sha/branch/tag>    Git commit SHA, branch, or tag to clone (default: main)"
-    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.0.2-v4.6.0)"
-    echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 14)"
+    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.1.0-v4.7.0)"
+    echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 15)"
     echo "  -p, --required-programs <list>   Comma-separated program IDs to verify (default: from required-programs.txt)"
     echo "  --skip-push                      Build images but skip pushing to registry (for testing)"
     echo "  -h, --help                       Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                               # Use defaults (main branch, v4.0.2-v4.6.0)"
-    echo "  $0 -c develop -v v4.0.2-v4.6.0   # Use develop branch and v4.0.2-v4.6.0 image"
+    echo "  $0                               # Use defaults (main branch, v4.1.0-v4.7.0)"
+    echo "  $0 -c develop -v v4.1.0-v4.7.0   # Use develop branch and v4.1.0-v4.7.0 image"
     echo "  $0 --commit abc1234 --version latest"
     echo "  $0 --skip-push                   # Build locally without pushing"
     echo "  $0 -t 15                         # Use consensus version 15"
@@ -63,8 +63,8 @@ usage() {
 
 # Parse command line arguments
 GIT_REF="main"
-DEVNET_VERSION="v4.0.2-v4.6.0"
-CONSENSUS_VERSION=14
+DEVNET_VERSION="v4.1.0-v4.7.0"
+CONSENSUS_VERSION=15
 SKIP_PUSH=false
 REQUIRED_PROGRAMS=""
 

--- a/build-publish-image.sh
+++ b/build-publish-image.sh
@@ -124,11 +124,24 @@ retry_command() {
   return $return_code
 }
 
+# Resolve the upstream Leo source tag while keeping public image tags normalized.
+resolve_leo_source_tag() {
+  local leo_version="$1"
+
+  if [[ -n "${LEO_SOURCE_TAG:-}" ]]; then
+    echo "${LEO_SOURCE_TAG}"
+  elif [[ "$leo_version" == "v4.1.0" ]]; then
+    echo "leo-lang-v4.1.0"
+  else
+    echo "$leo_version"
+  fi
+}
+
 # Infer Rust toolchain version from upstream repo's rust-toolchain.toml
 # Falls back silently if fetching or parsing fails
 infer_rust_version() {
   local repo_url="$1"  # e.g., https://github.com/ProvableHQ/leo
-  local tag="$2"       # e.g., v4.0.2
+  local tag="$2"       # e.g., leo-lang-v4.1.0
 
   # Extract org/repo from GitHub URL (strip prefix and trailing .git)
   local repo_path
@@ -139,6 +152,10 @@ infer_rust_version() {
   channel=$(curl -sSf --max-time 10 "$raw_url" 2>/dev/null \
     | sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
     | tr -d '[:space:]') || true
+
+  if [[ "$channel" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    channel="${channel}.0"
+  fi
 
   if [[ -n "$channel" && "$channel" != *"nightly"* ]]; then
     echo "$channel"
@@ -199,7 +216,7 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Examples:"
       echo "  $0 --dockerfile leo.Dockerfile --image-name leo-lang --variant node24"
-      echo "  # Produces: leo-lang:v4.0.2-node24, leo-lang:latest"
+      echo "  # Produces: leo-lang:v4.1.0-node24, leo-lang:latest"
       exit 0
       ;;
     *)
@@ -211,14 +228,15 @@ done
 
 # Set project-specific version variables based on image name
 if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
-  PROJECT_VERSION=${LEO_VERSION:-"v4.0.2"}
+  PROJECT_VERSION=${LEO_VERSION:-"v4.1.0"}
+  LEO_SOURCE_TAG=$(resolve_leo_source_tag "$PROJECT_VERSION")
   PROJECT_VERSION_ARG="LEO_VERSION"
   PROJECT_REPO=${LEO_REPO:-"https://github.com/ProvableHQ/leo"}
   PROJECT_REPO_ARG="LEO_REPO"
 elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
   # Aleo-devnet uses both LEO and SNARKOS versions
-  LEO_VERSION=${LEO_VERSION:-"v4.0.2"}
-  SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.6.0"}
+  LEO_VERSION=${LEO_VERSION:-"v4.1.0"}
+  SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.7.0"}
   PROJECT_VERSION="${LEO_VERSION}-${SNARKOS_VERSION}"
   # For aleo-devnet, we'll pass both versions as build args
   PROJECT_VERSION_ARG="LEO_VERSION"
@@ -233,7 +251,7 @@ fi
 # Infer RUST_VERSION from upstream if not explicitly set
 if [[ -z "${RUST_VERSION:-}" ]]; then
   if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
-    INFERRED_RUST=$(infer_rust_version "$PROJECT_REPO" "$PROJECT_VERSION") || true
+    INFERRED_RUST=$(infer_rust_version "$PROJECT_REPO" "$LEO_SOURCE_TAG") || true
   elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
     INFERRED_RUST=$(infer_rust_version "https://github.com/ProvableHQ/snarkOS" "$SNARKOS_VERSION") || true
   fi
@@ -241,7 +259,11 @@ if [[ -z "${RUST_VERSION:-}" ]]; then
     RUST_VERSION="$INFERRED_RUST"
     echo "Inferred Rust toolchain version: $RUST_VERSION (from upstream rust-toolchain.toml)"
   else
-    RUST_VERSION="1.94.1"
+    if [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
+      RUST_VERSION="1.88.0"
+    else
+      RUST_VERSION="1.96.0"
+    fi
     echo "Could not infer Rust version, using default: $RUST_VERSION"
   fi
 fi
@@ -253,6 +275,9 @@ if [[ -n "$VARIANT" ]]; then
 fi
 if [[ -n "$PROJECT_REPO" ]]; then
   echo "Repository: $PROJECT_REPO"
+fi
+if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
+  echo "Leo source tag: $LEO_SOURCE_TAG"
 fi
 
 # Check registry credentials if we're pushing
@@ -299,6 +324,9 @@ build_and_push() {
     common_build_args+=("--build-arg" "${PROJECT_VERSION_ARG}=${PROJECT_VERSION}")
     if [[ -n "$PROJECT_REPO_ARG" ]]; then
       common_build_args+=("--build-arg" "${PROJECT_REPO_ARG}=${PROJECT_REPO}")
+    fi
+    if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
+      common_build_args+=("--build-arg" "LEO_SOURCE_TAG=${LEO_SOURCE_TAG}")
     fi
     common_build_args+=("--build-arg" "DEBIAN_RELEASE=${DEBIAN_RELEASE}")
     common_build_args+=("--build-arg" "RUST_VERSION=${RUST_VERSION}")

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,7 +18,7 @@ The build system consists of these primary workflows:
 
 3. **Update Detection** (`check-updates.yml`)
    - Monitors upstream Leo and snarkOS repositories for new versions
-   - Applies semantic versioning filters
+   - Filters Leo source releases to `leo-lang-v*`, normalizes them to `v*` image tags, and applies semantic versioning filters
    - Triggers `leo-lang` builds for new Leo versions
    - Triggers `aleo-devnet` builds for new Leo+snarkOS combinations
 
@@ -111,7 +111,7 @@ Each architecture builds and pushes by content digest, then a merge job creates 
 
 ```
 build-standard (amd64) ──→ push @sha256:abc...  ─┐
-                                                  ├─→ merge-standard ──→ tag: v4.0.2
+                                                  ├─→ merge-standard ──→ tag: v4.1.0
 build-standard (arm64) ──→ push @sha256:def...  ─┘
 ```
 
@@ -123,14 +123,22 @@ Trigger builds via GitHub Actions UI or the `gh` CLI:
 
 ```bash
 # Build a leo-lang image
-gh workflow run manual-build.yml -f image_name=leo-lang -f leo_version=v4.0.2
+gh workflow run manual-build.yml \
+  -f image_name=leo-lang \
+  -f leo_version=v4.1.0 \
+  -f leo_source_tag=leo-lang-v4.1.0
 
 # Build an aleo-devnet image
-gh workflow run manual-build.yml -f image_name=aleo-devnet -f leo_version=v4.0.2 -f snarkos_version=v4.6.0
+gh workflow run manual-build.yml \
+  -f image_name=aleo-devnet \
+  -f leo_version=v4.1.0 \
+  -f snarkos_version=v4.7.0
 
 # Build a deployment snapshot
 gh workflow run build-publish-deployment-snapshot.yml \
-  -f git-ref=main -f aleo-devnet-version=v4.0.2-v4.6.0
+  -f git-ref=main \
+  -f aleo-devnet-version=v4.1.0-v4.7.0 \
+  -f consensus-version=15
 
 # Check for upstream version updates
 gh workflow run check-updates.yml
@@ -141,18 +149,19 @@ gh workflow run check-updates.yml
 ### Automated Version Detection
 
 1. The weekly check uses GitHub API to fetch release tags from upstream
-2. It normalizes version strings for proper semantic comparison
-3. Tags below the minimum version threshold are filtered out
-4. Existing registry tags are checked to avoid duplicate builds
-5. For each new qualifying tag, a build workflow is triggered
-6. Images are built and published to the GitHub Container Registry
+2. Leo source tags are filtered to `leo-lang-v*` and normalized to public `v*` image tags
+3. It normalizes version strings for proper semantic comparison
+4. Tags below the minimum version threshold are filtered out
+5. Existing registry tags are checked to avoid duplicate builds
+6. For each new qualifying tag, a build workflow is triggered
+7. Images are built and published to the GitHub Container Registry
 
 ### Deployment Snapshot Creation
 
 1. The workflow clones the compliant-transfer-aleo repository at the specified ref
 2. Resolves required programs from `required-programs.txt` (or the `required-programs` input override). Publish flows fail if the list is empty.
 3. Starts an Aleo devnet container with volume mounted at `/aleo/data` (only ledger state)
-4. Waits for the devnet consensus version to reach the target (default: >= 14)
+4. Waits for the devnet consensus version to reach the target (default: >= 15, with generated heights `0..14`)
 5. Installs dependencies and builds the programs
 6. Deploys the programs to the local devnet
 7. **Pre-shutdown verification**: Queries the REST API for each required program (retries up to 10x)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,11 +34,15 @@ Prover download and entrypoint script execution happen as `leo` user. The UID is
 
 Two layers of Rust version management work together:
 
-1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Falls back to `1.94.1` if inference fails or the channel is nightly.
+1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Leo inference uses `LEO_SOURCE_TAG` (default `leo-lang-v4.1.0` for image tag `v4.1.0`), while snarkOS inference uses `SNARKOS_VERSION`.
 
 2. **Dockerfile-level deferral**: The actual Rust compiler used is determined by the upstream `rust-toolchain.toml` copied from the cloned repo during the planner stage. The base image just needs `rustup` to install the required toolchain.
 
-In practice, inference (step 1) tries to align the base image with what the Dockerfile will need (step 2), avoiding an unnecessary toolchain download. Set `RUST_VERSION` explicitly only to override.
+In practice, inference (step 1) tries to align the base image with what the Dockerfile will need (step 2), avoiding an unnecessary toolchain download. Set `RUST_VERSION` explicitly only to override. Keep Rust per component: Leo `v4.1.0` requires Rust `1.96.0`; snarkOS `v4.7.0` still declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
+
+## Leo Source Tags vs Image Tags
+
+Published image tags are normalized (`ghcr.io/sealance-io/leo-lang:v4.1.0`), but upstream Leo source uses `leo-lang-v4.1.0`. `LEO_VERSION` controls the image tag and metadata; `LEO_SOURCE_TAG` controls the git clone and Rust toolchain inference. If unset, `LEO_SOURCE_TAG` derives `leo-lang-v4.1.0` only for the default `LEO_VERSION=v4.1.0`; older/manual versions fall back to `LEO_VERSION`.
 
 ## Prover Downloads
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -26,12 +26,15 @@
 
 ## Environment Variables
 
-`RUST_VERSION` is auto-inferred from the upstream `rust-toolchain.toml` — only set it to override.
+`RUST_VERSION` is auto-inferred from the upstream `rust-toolchain.toml` — only set it to override. Leo and snarkOS keep separate Rust policies: Leo `v4.1.0` uses Rust `1.96.0`, while snarkOS `v4.7.0` declares Rust `1.88` and Docker base tags normalize to `1.88.0`.
+
+Leo image tags and source tags are intentionally separate. `LEO_VERSION=v4.1.0` is the public image tag, while `LEO_SOURCE_TAG=leo-lang-v4.1.0` is the upstream git tag used for clone and Rust inference. If `LEO_SOURCE_TAG` is empty, only the default `LEO_VERSION=v4.1.0` derives `leo-lang-v4.1.0`; other versions fall back to `LEO_VERSION`.
 
 | Variable | Applies to | Default | Description |
 |---|---|---|---|
-| `LEO_VERSION` | both | `v4.0.2` | Leo release tag |
-| `SNARKOS_VERSION` | aleo-devnet | `v4.6.0` | snarkOS release tag |
+| `LEO_VERSION` | both | `v4.1.0` | Normalized Leo image/version tag |
+| `LEO_SOURCE_TAG` | leo-lang | `leo-lang-v4.1.0` | Upstream Leo source tag |
+| `SNARKOS_VERSION` | aleo-devnet | `v4.7.0` | snarkOS release tag |
 | `LEO_REPO` | both | ProvableHQ/leo | Leo Git URL |
 | `RUST_VERSION` | both | auto-inferred | Rust base image tag |
 | `NODE_VERSION` | leo-lang | `24` | Node.js major version |
@@ -40,14 +43,14 @@
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.0.2" SNARKOS_VERSION="v4.6.0" \
+LEO_VERSION="v4.1.0" SNARKOS_VERSION="v4.7.0" \
   ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Build from a fork
-LEO_REPO="https://github.com/your-fork/leo" \
+LEO_REPO="https://github.com/your-fork/leo" LEO_SOURCE_TAG="leo-lang-v4.1.0" \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 
 # Override Rust version (rarely needed)
-RUST_VERSION=1.85.0 \
+RUST_VERSION=1.96.0 \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 ```

--- a/docs/devnet.md
+++ b/docs/devnet.md
@@ -49,7 +49,7 @@ This means snapshot images are fully configurable via `-e` env vars, just like t
 1. Clone `sealance-io/compliant-transfer-aleo` at specified commit (SSH with fallback)
 2. `npm ci --ignore-scripts` + `npm run postinstall` + `npm run build` + `npm run compile`
 3. Start devnet container with volume mounted at `/aleo/data` (only captures ledger state, not runtime files)
-4. Generate `CONSENSUS_VERSION_HEIGHTS=0,1,2,...,N-1` to accelerate reaching target consensus version
+4. Generate `CONSENSUS_VERSION_HEIGHTS=0,1,2,...,N-1` to accelerate reaching target consensus version (default target: `15`, default heights: `0..14`)
 5. Poll `http://localhost:3030/testnet/consensus_version` until >= target (max 100 retries, 5s apart)
 6. Deploy programs via `npm run deploy:devnet`
 7. **Pre-shutdown verification**: Query REST API for each program in `required-programs.txt` (retries up to 10x)

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -3,14 +3,15 @@
 ARG NODE_VERSION=24
 ARG DEBIAN_RELEASE=trixie
 # Used to pin Rust base images.
-ARG RUST_VERSION=1.94.1
+ARG RUST_VERSION=1.96.0
 
 # =============================================================================
 # Stage 0: Planner - Generate cargo-chef recipe for dependency caching
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as planner
 
-ARG LEO_VERSION=v4.0.2
+ARG LEO_VERSION=v4.1.0
+ARG LEO_SOURCE_TAG=leo-lang-v4.1.0
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Install cargo-chef and git
@@ -23,7 +24,7 @@ WORKDIR /app
 
 # Clone repo and generate recipe.json (captures dependency information)
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-RUN git clone -b "${LEO_VERSION}" --recurse-submodules --single-branch --depth 1 "${LEO_REPO}"
+RUN git clone -b "${LEO_SOURCE_TAG}" --recurse-submodules --single-branch --depth 1 "${LEO_REPO}"
 
 WORKDIR /app/leo
 RUN cp rust-toolchain.toml /app/rust-toolchain.toml \
@@ -35,7 +36,8 @@ RUN cp rust-toolchain.toml /app/rust-toolchain.toml \
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as builder
 
-ARG LEO_VERSION=v4.0.2
+ARG LEO_VERSION=v4.1.0
+ARG LEO_SOURCE_TAG=leo-lang-v4.1.0
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Force rust to use external Git instead of the internal libgit wrapper
@@ -59,7 +61,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 # Now clone the actual source and build (only this step reruns on source changes)
 # Clone to /src to avoid conflict with cargo chef's generated structure
-RUN git clone -b "${LEO_VERSION}" --recurse-submodules --single-branch --depth 1 "${LEO_REPO}" /src/leo
+RUN git clone -b "${LEO_SOURCE_TAG}" --recurse-submodules --single-branch --depth 1 "${LEO_REPO}" /src/leo
 
 WORKDIR /src/leo
 
@@ -80,9 +82,13 @@ RUN cp /app/rust-toolchain.toml /src/leo/rust-toolchain.toml \
 # =============================================================================
 FROM node:${NODE_VERSION}-${DEBIAN_RELEASE}-slim as leo
 
-ARG LEO_REPO
+ARG LEO_VERSION=v4.1.0
+ARG LEO_SOURCE_TAG=leo-lang-v4.1.0
+ARG LEO_REPO=https://github.com/ProvableHQ/leo
 LABEL org.opencontainers.image.source="${LEO_REPO}"
 LABEL org.opencontainers.image.description="Leo CLI with NodeJS environment"
+LABEL leo.version="${LEO_VERSION}"
+LABEL leo.source-tag="${LEO_SOURCE_TAG}"
 
 # Copy leo-lang binary from the builder stage
 COPY --from=builder /usr/local/bin/leo /usr/local/bin/

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -15,7 +15,7 @@ ARG LEO_SOURCE_TAG=leo-lang-v4.1.0
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Install cargo-chef and git
-RUN cargo install cargo-chef \
+RUN cargo install cargo-chef --locked \
     && apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
@@ -47,7 +47,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # clang (libclang) + build-essential are required by librocksdb-sys, a transitive
 # dependency introduced in Leo v4.1.0: bindgen needs libclang and the bundled
 # RocksDB C++ sources need a C++ compiler. Mirrors aleo-devnet.Dockerfile's snarkOS builder.
-RUN cargo install cargo-chef \
+RUN cargo install cargo-chef --locked \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     git \

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -44,12 +44,17 @@ ARG LEO_REPO=https://github.com/ProvableHQ/leo
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Install cargo-chef and build dependencies
+# clang (libclang) + build-essential are required by librocksdb-sys, a transitive
+# dependency introduced in Leo v4.1.0: bindgen needs libclang and the bundled
+# RocksDB C++ sources need a C++ compiler. Mirrors aleo-devnet.Dockerfile's snarkOS builder.
 RUN cargo install cargo-chef \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     git \
     pkg-config \
     libssl-dev \
+    clang \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

  - Migrates Aleo container defaults to Aleo Stack 4.7.0:
    - Leo image tag: `v4.1.0`
    - Leo source tag: `leo-lang-v4.1.0`
    - snarkOS: `v4.7.0`
    - deployment snapshot consensus target: `15`
  - Adds explicit `LEO_SOURCE_TAG` handling so public image tags remain normalized while source clones/toolchain inference use upstream Leo source tags.
  - Updates build scripts, Dockerfiles, GitHub Actions workflows, README, docs, and agent guidance for the new defaults.
  - Updates release detection to filter Leo releases to `leo-lang-v*` and emit normalized `v*` image tags.
  - Pins deployment snapshot `setup-leo-action` usage to PR #19 head until a release SHA is available.

  ## Verification

  - `shellcheck --severity=warning ./*.sh`
  - `actionlint -color`
  - `bash -n build-publish-image.sh build-publish-deployment-snapshot.sh devnet-entrypoint.sh download-provers.sh`
  - Ruby YAML load for updated workflows
  - `git diff --check`
  - Local tag-normalization simulation: `leo-lang-v4.1.0` -> `v4.1.0`

  ## Notes

  - Did not run local container builds, per migration plan.
  - `hadolint` was not available locally, so Dockerfile linting should be covered in CI.