### PR TITLE
support leo v4.3.1

### DIFF
--- a/.github/workflows/build-publish-deployment-snapshot.yml
+++ b/.github/workflows/build-publish-deployment-snapshot.yml
@@ -11,7 +11,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.3.0-v4.8.1'
+        default: 'v4.3.1-v4.8.1'
         type: string
       image-name:
         description: 'Custom image name (without registry)'
@@ -53,7 +53,7 @@ on:
       aleo-devnet-version:
         description: 'Version tag for aleo-devnet base image'
         required: false
-        default: 'v4.3.0-v4.8.1'
+        default: 'v4.3.1-v4.8.1'
         type: string
       image-name:
         description: 'Custom image name (without registry)'

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -68,7 +68,7 @@ on:
       leo_version:
         description: 'Leo version for aleo-devnet (if different from project_version)'
         required: false
-        default: 'v4.3.0'
+        default: 'v4.3.1'
         type: string
     secrets:
       registry_token:
@@ -116,6 +116,8 @@ jobs:
                 LEO_SOURCE_TAG="leo-lang-v4.2.0"
               elif [[ "${INPUT_PROJECT_VERSION}" == "v4.3.0" ]]; then
                 LEO_SOURCE_TAG="leo-lang-v4.3.0"
+              elif [[ "${INPUT_PROJECT_VERSION}" == "v4.3.1" ]]; then
+                LEO_SOURCE_TAG="leo-lang-v4.3.1"
               else
                 LEO_SOURCE_TAG="${INPUT_PROJECT_VERSION}"
               fi
@@ -271,7 +273,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            LEO_VERSION=${{ inputs.leo_version || 'v4.3.0' }}
+            LEO_VERSION=${{ inputs.leo_version || 'v4.3.1' }}
             SNARKOS_VERSION=${{ inputs.snarkos_version || 'v4.8.1' }}
             SNARKOS_SOURCE_TAG=${{ needs.determine-params.outputs.snarkos_source_tag }}
             RUST_VERSION=${{ needs.determine-params.outputs.rust_version }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -11,10 +11,10 @@ on:
           - leo-lang
           - aleo-devnet
       leo_version:
-        description: 'Leo image version (e.g., v4.3.0)'
+        description: 'Leo image version (e.g., v4.3.1)'
         required: true
         type: string
-        default: 'v4.3.0'
+        default: 'v4.3.1'
       leo_source_tag:
         description: 'Leo upstream source tag (leo-lang only; blank derives default)'
         required: false
@@ -72,6 +72,8 @@ jobs:
                 LEO_SOURCE_TAG="leo-lang-v4.2.0"
               elif [[ "${LEO_VERSION}" == "v4.3.0" ]]; then
                 LEO_SOURCE_TAG="leo-lang-v4.3.0"
+              elif [[ "${LEO_VERSION}" == "v4.3.1" ]]; then
+                LEO_SOURCE_TAG="leo-lang-v4.3.1"
               else
                 LEO_SOURCE_TAG="${LEO_VERSION}"
               fi
@@ -93,7 +95,7 @@ jobs:
             fi
             {
               echo "dockerfile=aleo-devnet.Dockerfile"
-              # For aleo-devnet, project_version is combined: v4.3.0-v4.8.1
+              # For aleo-devnet, project_version is combined: v4.3.1-v4.8.1
               echo "project_version=${LEO_VERSION}-${SNARKOS_VERSION}"
               echo "leo_source_tag="
             } >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,14 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 
 ```bash
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
-./build-publish-deployment-snapshot.sh --commit main --version v4.3.0-v4.8.1 --consensus-version 16
+./build-publish-deployment-snapshot.sh --commit main --version v4.3.1-v4.8.1 --consensus-version 16
 ```
 
 ### Run Containers
 
 ```bash
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.0 leo --help
-docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.1 leo --help
+docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1
 curl http://localhost:3030/testnet/latest/height
 ```
 
@@ -69,11 +69,11 @@ All scripts use `set -euo pipefail` with `IFS=$'\n\t'` and are validated with [s
 
 - **Build order**: `leo-lang` must be built/published before `aleo-devnet` (`COPY --from` dependency)
 - **Version format**: Devnet tags are strictly `vX.Y.Z-vA.B.C` (Leo-snarkOS)
-- **Leo source tag split**: Public image tags stay normalized (`LEO_VERSION=v4.3.0`), while Leo `v4.3.0` clones from upstream `LEO_SOURCE_TAG=leo-lang-v4.3.0`
+- **Leo source tag split**: Public image tags stay normalized (`LEO_VERSION=v4.3.1`), while Leo `v4.3.1` clones from upstream `LEO_SOURCE_TAG=leo-lang-v4.3.1`; known `leo-lang-*` releases derive automatically when `LEO_SOURCE_TAG` is empty
 - **snarkOS source tag split**: Same pattern — image component stays normalized (`SNARKOS_VERSION=v4.8.1`), while the clone/Rust inference use `SNARKOS_SOURCE_TAG=testnet-v4.8.1` (recorded via the `snarkos.source-tag` label). Other versions (e.g. `v4.7.3`) pass through unchanged
 - **Minimum versions**: Leo >= v3.5.0, snarkOS >= v4.5.3 (required for non-root user and `/aleo/data` layout)
 - **Hadolint ignores**: `.hadolint.yaml` ignores DL3008 and DL3059 intentionally — do not remove
-- **Rust version**: `RUST_VERSION` is auto-inferred from upstream `rust-toolchain.toml`; keep it per component (Leo v4.3.0 uses 1.96.0, snarkOS v4.8.1 / `testnet-v4.8.1` declares 1.88 and Docker base tags normalize to 1.88.0)
+- **Rust version**: `RUST_VERSION` is auto-inferred from upstream `rust-toolchain.toml`; keep it per component (Leo v4.3.1 uses 1.96.0, snarkOS v4.8.1 / `testnet-v4.8.1` declares 1.88 and Docker base tags normalize to 1.88.0)
 - **Snapshot consensus**: Deployment snapshots default to consensus version 16 and generated heights `0..15`
 - **Fail-closed policy**: Publish flows require a non-empty program list from `required-programs.txt`
 - **SHA-pinned actions**: All workflow `uses:` reference full commit SHAs, not mutable tags — include version as trailing comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ snapshot Dockerfile (generated) → ghcr.io/sealance-io/aleo-devnet-custom:tag
 # Build aleo-devnet locally (requires leo-lang image)
 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --local-arch --no-push
 
-# Build deployment snapshot (default base v4.3.0-v4.8.1, consensus 16)
+# Build deployment snapshot (default base v4.3.1-v4.8.1, consensus 16)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push
 
 # Lint (required before completing any task)
@@ -65,11 +65,11 @@ Two layers work together:
 1. **Build-time inference**: `infer_rust_version()` in the build script (and CI) fetches upstream `rust-toolchain.toml` to set the Docker base image tag. Leo inference uses `LEO_SOURCE_TAG`; snarkOS inference uses `SNARKOS_SOURCE_TAG`.
 2. **Dockerfile-level**: The actual compiler is determined by `rust-toolchain.toml` copied from the cloned repo. The base image just needs `rustup`.
 
-`RUST_VERSION` is auto-inferred — only override explicitly. Keep Rust per component: Leo `v4.3.0` uses Rust `1.96.0`; snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
+`RUST_VERSION` is auto-inferred — only override explicitly. Keep Rust per component: Leo `v4.3.1` uses Rust `1.96.0`; snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
 
 ### Leo Source Tags vs Image Tags
 
-Public Leo image tags are normalized (`LEO_VERSION=v4.3.0`), but upstream source uses `LEO_SOURCE_TAG=leo-lang-v4.3.0`. `LEO_VERSION` controls published image tags; `LEO_SOURCE_TAG` controls the Leo git clone and Rust inference. If unset, only the default `v4.3.0` derives `leo-lang-v4.3.0`; other versions fall back to `LEO_VERSION`.
+Public Leo image tags are normalized (`LEO_VERSION=v4.3.1`), but upstream source uses `LEO_SOURCE_TAG=leo-lang-v4.3.1`. `LEO_VERSION` controls published image tags; `LEO_SOURCE_TAG` controls the Leo git clone and Rust inference. If unset, known Leo releases with `leo-lang-*` upstream tags derive the matching source tag automatically; other versions fall back to `LEO_VERSION`.
 
 ### snarkOS Source Tags vs Image Tags
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository provides multi-architecture (AMD64/ARM64) Docker images for Aleo
 
 Pre-built images are available on GitHub Container Registry:
 
-- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.3.0`
-- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1`
+- **Leo Lang**: `ghcr.io/sealance-io/leo-lang:v4.3.1`
+- **Aleo Devnet**: `ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1`
 
 ### Custom Deployment Snapshots
 - **With deployed programs**: `ghcr.io/sealance-io/aleo-devnet-custom:latest`
@@ -22,13 +22,13 @@ You can also use the `latest` tag to always get the most recent version.
 ### Image Contents
 
 #### Leo Lang (`leo-lang`)
-- Leo CLI v4.3.0
+- Leo CLI v4.3.1
 - Node.js v24
 - Debian trixie (slim)
 - Essential SSL libraries
 
 #### Aleo Devnet Image (`aleo-devnet`)
-- Leo CLI v4.3.0
+- Leo CLI v4.3.1
 - snarkOS v4.8.1
 - Pre-downloaded mainnet prover parameters (~2GB)
 - Debian trixie (slim)
@@ -43,16 +43,16 @@ For development, deployment, and running Leo applications:
 
 ```bash
 # Run the Leo CLI directly
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.0 leo --help
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.1 leo --help
 
 # Check installed versions
-docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.0
+docker run --rm ghcr.io/sealance-io/leo-lang:v4.3.1
 
 # Mount your project directory and work with Leo
-docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.3.0 leo build
+docker run --rm -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.3.1 leo build
 
 # Start a shell in the container
-docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.3.0 /bin/bash
+docker run --rm -it -v $(pwd):/app -w /app ghcr.io/sealance-io/leo-lang:v4.3.1 /bin/bash
 ```
 
 ### Aleo Devnet Image
@@ -63,25 +63,25 @@ For running a local Aleo development network with Leo and snarkOS:
 # Run a minimal devnet (4 validators + 1 client)
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1
+  ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1
 
 # Run with custom devnet parameters
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   -v $(pwd)/data:/aleo/data \
-  ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1 \
+  ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1 \
   devnet --storage /aleo/data --clear-storage --yes \
   --verbosity 4 --num-validators 4 --num-clients 2
 
 # Run snarkOS directly instead of Leo devnet command
 docker run -it --rm -p 3030:3030 -p 4130:4130 \
   --entrypoint ./snarkos \
-  ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1 \
+  ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1 \
   start --client --nodisplay --node 0.0.0.0:4130 \
   --network 1 --dev 0 --rest 0.0.0.0:3030
 
 # Access Leo CLI for development
 docker run -it --rm -v $(pwd):/app -w /app \
-  ghcr.io/sealance-io/aleo-devnet:v4.3.0-v4.8.1 \
+  ghcr.io/sealance-io/aleo-devnet:v4.3.1-v4.8.1 \
   new my_project
 ```
 #### GitHub Actions Example
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Leo CLI
         uses: sealance-io/setup-leo-action@3fb8fc821388716961eee9146b414fcfc093b32d # v1.1.3
         with:
-          version: '4.3.0'
+          version: '4.3.1'
           rust-version: '1.96.0'
 
       - name: Build Leo project
@@ -120,12 +120,12 @@ See [setup-leo-action](https://github.com/sealance-io/setup-leo-action) for more
 
 ### Leo Image Tags vs Source Tags
 
-Published image tags stay normalized as `v4.3.0`, but the upstream Leo source tag for this release is `leo-lang-v4.3.0`. Build scripts and workflows keep these separate:
+Published image tags stay normalized as `v4.3.1`, but the upstream Leo source tag for this release is `leo-lang-v4.3.1`. Build scripts and workflows keep these separate:
 
-- `LEO_VERSION=v4.3.0` controls the public image tag.
-- `LEO_SOURCE_TAG=leo-lang-v4.3.0` controls the upstream git clone and Rust toolchain inference.
+- `LEO_VERSION=v4.3.1` controls the public image tag.
+- `LEO_SOURCE_TAG=leo-lang-v4.3.1` controls the upstream git clone and Rust toolchain inference.
 
-When `LEO_SOURCE_TAG` is empty, the default `LEO_VERSION=v4.3.0` derives `leo-lang-v4.3.0`; other Leo versions fall back to using `LEO_VERSION` as the source tag for compatibility.
+When `LEO_SOURCE_TAG` is empty, known Leo releases with `leo-lang-*` upstream tags derive the matching source tag automatically; other Leo versions fall back to using `LEO_VERSION` as the source tag for compatibility.
 
 ### snarkOS Image Tags vs Source Tags
 
@@ -135,6 +135,8 @@ snarkOS uses the same split. The `aleo-devnet` image component stays a normalize
 - `SNARKOS_SOURCE_TAG=testnet-v4.8.1` controls the upstream git clone and Rust toolchain inference (recorded via the `snarkos.source-tag` label).
 
 This is needed because `v4.8.1` is published from the pre-release tag `testnet-v4.8.1`. When `SNARKOS_SOURCE_TAG` is empty, the default `SNARKOS_VERSION=v4.8.1` derives `testnet-v4.8.1`; other snarkOS versions (e.g. `v4.7.3`) fall back to using `SNARKOS_VERSION` as the source tag.
+
+The current default pair is `v4.3.1-v4.8.1`. Leo `leo-lang-v4.3.1` resolves snarkVM through the `testnet-v4.8.0` line, and snarkOS `testnet-v4.8.1` pins the same snarkVM commit (`357899f8e85d6340bda5db8373b1cdffdf88a6d7`).
 
 ## 🔄 CI/CD Automation
 
@@ -195,10 +197,10 @@ The repository includes a script to create custom Aleo devnet images with pre-de
 ./build-publish-deployment-snapshot.sh --commit abc1234 --skip-push
 
 # Build with custom base image version
-./build-publish-deployment-snapshot.sh --version v4.3.0-v4.8.1 --skip-push
+./build-publish-deployment-snapshot.sh --version v4.3.1-v4.8.1 --skip-push
 
 # Build and push to registry (requires authentication)
-./build-publish-deployment-snapshot.sh --commit main --version v4.3.0-v4.8.1
+./build-publish-deployment-snapshot.sh --commit main --version v4.3.1-v4.8.1
 
 # Override required programs for verification (default: from required-programs.txt)
 ./build-publish-deployment-snapshot.sh --commit main --skip-push --required-programs "merkle_tree.aleo,custom.aleo"
@@ -237,19 +239,19 @@ The `--variant` flag allows you to add a suffix to version tags (not `latest`), 
 ```bash
 # Build Leo with Node.js 24
 NODE_VERSION=24 ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang --variant node24
-# Produces: leo-lang:v4.3.0-node24, leo-lang:latest
+# Produces: leo-lang:v4.3.1-node24, leo-lang:latest
 
 # Build with custom Rust version
 RUST_VERSION=1.88.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet --variant rust188
-# Produces: aleo-devnet:v4.3.0-v4.8.1-rust188, aleo-devnet:latest
+# Produces: aleo-devnet:v4.3.1-v4.8.1-rust188, aleo-devnet:latest
 ```
 
 ### Environment Variables
 
 | Variable | Applies to | Description |
 |---|---|---|
-| `LEO_VERSION` | both | Normalized Leo image/version tag (default: `v4.3.0`) |
-| `LEO_SOURCE_TAG` | leo-lang | Upstream Leo source tag used for clone/toolchain inference (default: `leo-lang-v4.3.0` when `LEO_VERSION=v4.3.0`) |
+| `LEO_VERSION` | both | Normalized Leo image/version tag (default: `v4.3.1`) |
+| `LEO_SOURCE_TAG` | leo-lang | Upstream Leo source tag used for clone/toolchain inference (default: `leo-lang-v4.3.1` when `LEO_VERSION=v4.3.1`) |
 | `SNARKOS_VERSION` | aleo-devnet | Normalized snarkOS image/version tag (default: `v4.8.1`) |
 | `SNARKOS_SOURCE_TAG` | aleo-devnet | Upstream snarkOS source tag used for clone/toolchain inference (default: `testnet-v4.8.1` when `SNARKOS_VERSION=v4.8.1`) |
 | `LEO_REPO` | both | Leo Git URL (default: ProvableHQ/leo) |
@@ -260,7 +262,7 @@ RUST_VERSION=1.88.0 ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.3.0" LEO_SOURCE_TAG="leo-lang-v4.3.0" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
+LEO_VERSION="v4.3.1" LEO_SOURCE_TAG="leo-lang-v4.3.1" LEO_REPO="https://github.com/your-fork/leo" NODE_VERSION=18 \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 ```
 
@@ -291,7 +293,7 @@ echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 Add the appropriate user permissions:
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.3.0 leo build
+docker run --rm -v $(pwd):/app -w /app --user $(id -u):$(id -g) ghcr.io/sealance-io/leo-lang:v4.3.1 leo build
 ```
 
 ## 📜 License

--- a/aleo-devnet.Dockerfile
+++ b/aleo-devnet.Dockerfile
@@ -3,7 +3,7 @@
 # Run: docker run -it --rm -p 3030:3030 -p 4130:4130 -v $(pwd)/data:/aleo/data aleo-devnet
 
 # Build arguments
-ARG LEO_VERSION=v4.3.0
+ARG LEO_VERSION=v4.3.1
 ARG SNARKOS_VERSION=v4.8.1
 # Upstream snarkOS source tag. The image component stays a normalized vX.Y.Z tag
 # (SNARKOS_VERSION), while the git clone / Rust inference may use a non-normalized
@@ -48,9 +48,9 @@ ARG SNARKOS_SOURCE_TAG
 
 # Install cargo-chef and build dependencies
 # libclang-dev provides libclang.so for clang-sys/bindgen, a transitive build
-# dependency introduced by snarkOS testnet-v4.8.1 (snarkVM v4.8.0 line). The
-# clang package alone ships only versioned runtime libs; clang-sys searches for
-# the unversioned libclang.so symlink that libclang-dev installs.
+# dependency introduced by snarkOS testnet-v4.8.1 (snarkVM testnet-v4.8.0 line).
+# The clang package alone ships only versioned runtime libs; clang-sys searches
+# for the unversioned libclang.so symlink that libclang-dev installs.
 RUN cargo install cargo-chef --locked \
     && apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/build-publish-deployment-snapshot.sh
+++ b/build-publish-deployment-snapshot.sh
@@ -39,15 +39,15 @@ usage() {
     echo ""
     echo "Options:"
     echo "  -c, --commit <sha/branch/tag>    Git commit SHA, branch, or tag to clone (default: main)"
-    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.3.0-v4.8.1)"
+    echo "  -v, --version <version>          Version tag for aleo-devnet image (default: v4.3.1-v4.8.1)"
     echo "  -t, --consensus-version <num>    Target consensus version for devnet (default: 16)"
     echo "  -p, --required-programs <list>   Comma-separated program IDs to verify (default: from required-programs.txt)"
     echo "  --skip-push                      Build images but skip pushing to registry (for testing)"
     echo "  -h, --help                       Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                               # Use defaults (main branch, v4.3.0-v4.8.1)"
-    echo "  $0 -c develop -v v4.3.0-v4.8.1   # Use develop branch and v4.3.0-v4.8.1 image"
+    echo "  $0                               # Use defaults (main branch, v4.3.1-v4.8.1)"
+    echo "  $0 -c develop -v v4.3.1-v4.8.1   # Use develop branch and v4.3.1-v4.8.1 image"
     echo "  $0 --commit abc1234 --version latest"
     echo "  $0 --skip-push                   # Build locally without pushing"
     echo "  $0 -t 16                         # Use consensus version 16"
@@ -63,7 +63,7 @@ usage() {
 
 # Parse command line arguments
 GIT_REF="main"
-DEVNET_VERSION="v4.3.0-v4.8.1"
+DEVNET_VERSION="v4.3.1-v4.8.1"
 CONSENSUS_VERSION=16
 SKIP_PUSH=false
 REQUIRED_PROGRAMS=""

--- a/build-publish-image.sh
+++ b/build-publish-image.sh
@@ -136,6 +136,8 @@ resolve_leo_source_tag() {
     echo "leo-lang-v4.2.0"
   elif [[ "$leo_version" == "v4.3.0" ]]; then
     echo "leo-lang-v4.3.0"
+  elif [[ "$leo_version" == "v4.3.1" ]]; then
+    echo "leo-lang-v4.3.1"
   else
     echo "$leo_version"
   fi
@@ -235,7 +237,7 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Examples:"
       echo "  $0 --dockerfile leo.Dockerfile --image-name leo-lang --variant node24"
-      echo "  # Produces: leo-lang:v4.3.0-node24, leo-lang:latest"
+      echo "  # Produces: leo-lang:v4.3.1-node24, leo-lang:latest"
       exit 0
       ;;
     *)
@@ -247,14 +249,14 @@ done
 
 # Set project-specific version variables based on image name
 if [[ "$IMAGE_NAME" == "leo-lang" ]]; then
-  PROJECT_VERSION=${LEO_VERSION:-"v4.3.0"}
+  PROJECT_VERSION=${LEO_VERSION:-"v4.3.1"}
   LEO_SOURCE_TAG=$(resolve_leo_source_tag "$PROJECT_VERSION")
   PROJECT_VERSION_ARG="LEO_VERSION"
   PROJECT_REPO=${LEO_REPO:-"https://github.com/ProvableHQ/leo"}
   PROJECT_REPO_ARG="LEO_REPO"
 elif [[ "$IMAGE_NAME" == "aleo-devnet" ]]; then
   # Aleo-devnet uses both LEO and SNARKOS versions
-  LEO_VERSION=${LEO_VERSION:-"v4.3.0"}
+  LEO_VERSION=${LEO_VERSION:-"v4.3.1"}
   SNARKOS_VERSION=${SNARKOS_VERSION:-"v4.8.1"}
   SNARKOS_SOURCE_TAG=$(resolve_snarkos_source_tag "$SNARKOS_VERSION")
   # Image component stays normalized; SNARKOS_SOURCE_TAG drives clone/Rust inference.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -105,7 +105,7 @@ Each architecture builds and pushes by content digest, then a merge job creates 
 
 ```
 build-standard (amd64) ──→ push @sha256:abc...  ─┐
-                                                  ├─→ merge-standard ──→ tag: v4.3.0
+                                                  ├─→ merge-standard ──→ tag: v4.3.1
 build-standard (arm64) ──→ push @sha256:def...  ─┘
 ```
 
@@ -119,19 +119,19 @@ Trigger builds via GitHub Actions UI or the `gh` CLI:
 # Build a leo-lang image
 gh workflow run manual-build.yml \
   -f image_name=leo-lang \
-  -f leo_version=v4.3.0 \
-  -f leo_source_tag=leo-lang-v4.3.0
+  -f leo_version=v4.3.1 \
+  -f leo_source_tag=leo-lang-v4.3.1
 
 # Build an aleo-devnet image
 gh workflow run manual-build.yml \
   -f image_name=aleo-devnet \
-  -f leo_version=v4.3.0 \
+  -f leo_version=v4.3.1 \
   -f snarkos_version=v4.8.1
 
 # Build a deployment snapshot
 gh workflow run build-publish-deployment-snapshot.yml \
   -f git-ref=main \
-  -f aleo-devnet-version=v4.3.0-v4.8.1 \
+  -f aleo-devnet-version=v4.3.1-v4.8.1 \
   -f consensus-version=16
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,19 +34,21 @@ Prover download and entrypoint script execution happen as `leo` user. The UID is
 
 Two layers of Rust version management work together:
 
-1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Leo inference uses `LEO_SOURCE_TAG` (default `leo-lang-v4.3.0` for image tag `v4.3.0`), while snarkOS inference uses `SNARKOS_SOURCE_TAG` (default `testnet-v4.8.1` for image tag `v4.8.1`).
+1. **Build-time inference** (`build-publish-image.sh` and CI): If `RUST_VERSION` is not explicitly set, `infer_rust_version()` fetches the upstream project's `rust-toolchain.toml` from GitHub and extracts the `channel` value. This sets the Docker **base image** tag (`rust:${RUST_VERSION}-slim-trixie`). Leo inference uses `LEO_SOURCE_TAG` (default `leo-lang-v4.3.1` for image tag `v4.3.1`), while snarkOS inference uses `SNARKOS_SOURCE_TAG` (default `testnet-v4.8.1` for image tag `v4.8.1`).
 
 2. **Dockerfile-level deferral**: The actual Rust compiler used is determined by the upstream `rust-toolchain.toml` copied from the cloned repo during the planner stage. The base image just needs `rustup` to install the required toolchain.
 
-In practice, inference (step 1) tries to align the base image with what the Dockerfile will need (step 2), avoiding an unnecessary toolchain download. Set `RUST_VERSION` explicitly only to override. Keep Rust per component: Leo `v4.3.0` requires Rust `1.96.0`; snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) still declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
+In practice, inference (step 1) tries to align the base image with what the Dockerfile will need (step 2), avoiding an unnecessary toolchain download. Set `RUST_VERSION` explicitly only to override. Keep Rust per component: Leo `v4.3.1` requires Rust `1.96.0`; snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) still declares Rust `1.88`, normalized to Docker base tag `1.88.0`.
 
 ## Leo Source Tags vs Image Tags
 
-Published image tags are normalized (`ghcr.io/sealance-io/leo-lang:v4.3.0`), but upstream Leo source uses `leo-lang-v4.3.0`. `LEO_VERSION` controls the image tag and metadata; `LEO_SOURCE_TAG` controls the git clone and Rust toolchain inference. If unset, `LEO_SOURCE_TAG` derives `leo-lang-v4.3.0` only for the default `LEO_VERSION=v4.3.0`; older/manual versions fall back to `LEO_VERSION`.
+Published image tags are normalized (`ghcr.io/sealance-io/leo-lang:v4.3.1`), but upstream Leo source uses `leo-lang-v4.3.1`. `LEO_VERSION` controls the image tag and metadata; `LEO_SOURCE_TAG` controls the git clone and Rust toolchain inference. If unset, known Leo releases with `leo-lang-*` upstream tags derive the matching source tag automatically; older/manual versions fall back to `LEO_VERSION`.
 
 ## snarkOS Source Tags vs Image Tags
 
 snarkOS uses the same split as Leo. The `aleo-devnet` image component stays a normalized `vX.Y.Z` tag (`SNARKOS_VERSION`, e.g. `v4.8.1`, used for image tags and the `snarkos.version` label), while `SNARKOS_SOURCE_TAG` controls the git clone and Rust toolchain inference. This matters when upstream ships a release under a non-`vX.Y.Z` tag: `v4.8.1` is published from the pre-release tag `testnet-v4.8.1`. If unset, `SNARKOS_SOURCE_TAG` derives `testnet-v4.8.1` only for `SNARKOS_VERSION=v4.8.1`; other versions (e.g. `v4.7.3`) fall back to using `SNARKOS_VERSION` unchanged. The resolved source tag is recorded on the image via the `snarkos.source-tag` label.
+
+For the current default devnet image, Leo `leo-lang-v4.3.1` and snarkOS `testnet-v4.8.1` both resolve snarkVM to commit `357899f8e85d6340bda5db8373b1cdffdf88a6d7`.
 
 ## Prover Downloads
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -26,16 +26,18 @@
 
 ## Environment Variables
 
-`RUST_VERSION` is auto-inferred from the upstream `rust-toolchain.toml` — only set it to override. Leo and snarkOS keep separate Rust policies: Leo `v4.3.0` uses Rust `1.96.0`, while snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) declares Rust `1.88` and Docker base tags normalize to `1.88.0`.
+`RUST_VERSION` is auto-inferred from the upstream `rust-toolchain.toml` — only set it to override. Leo and snarkOS keep separate Rust policies: Leo `v4.3.1` uses Rust `1.96.0`, while snarkOS `v4.8.1` (source tag `testnet-v4.8.1`) declares Rust `1.88` and Docker base tags normalize to `1.88.0`.
 
-Leo image tags and source tags are intentionally separate. `LEO_VERSION=v4.3.0` is the public image tag, while `LEO_SOURCE_TAG=leo-lang-v4.3.0` is the upstream git tag used for clone and Rust inference. If `LEO_SOURCE_TAG` is empty, only the default `LEO_VERSION=v4.3.0` derives `leo-lang-v4.3.0`; other versions fall back to `LEO_VERSION`.
+Leo image tags and source tags are intentionally separate. `LEO_VERSION=v4.3.1` is the public image tag, while `LEO_SOURCE_TAG=leo-lang-v4.3.1` is the upstream git tag used for clone and Rust inference. If `LEO_SOURCE_TAG` is empty, known Leo releases with `leo-lang-*` upstream tags derive the matching source tag automatically; other versions fall back to `LEO_VERSION`.
 
 snarkOS uses the same split: `SNARKOS_VERSION=v4.8.1` is the normalized image component, while `SNARKOS_SOURCE_TAG=testnet-v4.8.1` is the upstream git tag used for clone and Rust inference (needed because `v4.8.1` ships from the pre-release tag `testnet-v4.8.1`). If `SNARKOS_SOURCE_TAG` is empty, only the default `SNARKOS_VERSION=v4.8.1` derives `testnet-v4.8.1`; other versions (e.g. `v4.7.3`) fall back to `SNARKOS_VERSION`.
 
+The default `v4.3.1-v4.8.1` devnet pair is aligned on snarkVM commit `357899f8e85d6340bda5db8373b1cdffdf88a6d7` (Leo via `testnet-v4.8.0`, snarkOS via its pinned rev).
+
 | Variable | Applies to | Default | Description |
 |---|---|---|---|
-| `LEO_VERSION` | both | `v4.3.0` | Normalized Leo image/version tag |
-| `LEO_SOURCE_TAG` | leo-lang | `leo-lang-v4.3.0` | Upstream Leo source tag |
+| `LEO_VERSION` | both | `v4.3.1` | Normalized Leo image/version tag |
+| `LEO_SOURCE_TAG` | leo-lang | `leo-lang-v4.3.1` | Upstream Leo source tag |
 | `SNARKOS_VERSION` | aleo-devnet | `v4.8.1` | Normalized snarkOS image/version tag |
 | `SNARKOS_SOURCE_TAG` | aleo-devnet | `testnet-v4.8.1` | Upstream snarkOS source tag |
 | `LEO_REPO` | both | ProvableHQ/leo | Leo Git URL |
@@ -46,11 +48,11 @@ snarkOS uses the same split: `SNARKOS_VERSION=v4.8.1` is the normalized image co
 
 ```bash
 # Example: multiple overrides
-LEO_VERSION="v4.3.0" SNARKOS_VERSION="v4.8.1" \
+LEO_VERSION="v4.3.1" SNARKOS_VERSION="v4.8.1" \
   ./build-publish-image.sh --dockerfile aleo-devnet.Dockerfile --image-name aleo-devnet
 
 # Build from a fork
-LEO_REPO="https://github.com/your-fork/leo" LEO_SOURCE_TAG="leo-lang-v4.3.0" \
+LEO_REPO="https://github.com/your-fork/leo" LEO_SOURCE_TAG="leo-lang-v4.3.1" \
   ./build-publish-image.sh --dockerfile leo.Dockerfile --image-name leo-lang
 
 # Override Rust version (rarely needed)

--- a/leo.Dockerfile
+++ b/leo.Dockerfile
@@ -10,8 +10,8 @@ ARG RUST_VERSION=1.96.0
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as planner
 
-ARG LEO_VERSION=v4.3.0
-ARG LEO_SOURCE_TAG=leo-lang-v4.3.0
+ARG LEO_VERSION=v4.3.1
+ARG LEO_SOURCE_TAG=leo-lang-v4.3.1
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Install cargo-chef and git
@@ -36,8 +36,8 @@ RUN cp rust-toolchain.toml /app/rust-toolchain.toml \
 # =============================================================================
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} as builder
 
-ARG LEO_VERSION=v4.3.0
-ARG LEO_SOURCE_TAG=leo-lang-v4.3.0
+ARG LEO_VERSION=v4.3.1
+ARG LEO_SOURCE_TAG=leo-lang-v4.3.1
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 
 # Force rust to use external Git instead of the internal libgit wrapper
@@ -87,8 +87,8 @@ RUN cp /app/rust-toolchain.toml /src/leo/rust-toolchain.toml \
 # =============================================================================
 FROM node:${NODE_VERSION}-${DEBIAN_RELEASE}-slim as leo
 
-ARG LEO_VERSION=v4.3.0
-ARG LEO_SOURCE_TAG=leo-lang-v4.3.0
+ARG LEO_VERSION=v4.3.1
+ARG LEO_SOURCE_TAG=leo-lang-v4.3.1
 ARG LEO_REPO=https://github.com/ProvableHQ/leo
 LABEL org.opencontainers.image.source="${LEO_REPO}"
 LABEL org.opencontainers.image.description="Leo CLI with NodeJS environment"


### PR DESCRIPTION
## Summary

- Make Leo `v4.3.1` the default for `leo-lang`, `aleo-devnet`, and deployment snapshot flows.
- Add `v4.3.1 -> leo-lang-v4.3.1` source-tag derivation while preserving existing `v4.3.0` support.
- Keep compatible snarkOS at `v4.8.1` / `testnet-v4.8.1` and document the shared snarkVM commit alignment.

## Verification

- `git diff --check`
- `bash -n build-publish-image.sh build-publish-deployment-snapshot.sh devnet-entrypoint.sh download-provers.sh`
- `shellcheck --severity=warning *.sh`
- `hadolint leo.Dockerfile aleo-devnet.Dockerfile`
- Verified upstream Leo `leo-lang-v4.3.1` uses Rust `1.96.0`; snarkOS `testnet-v4.8.1` uses Rust `1.88`; both align on snarkVM commit `357899f8e85d6340bda5db8373b1cdffdf88a6d7`.

## Notes

- Local container builds were not run; CI should build `leo-lang:v4.3.1` before `aleo-devnet:v4.3.1-v4.8.1`.